### PR TITLE
V2.1 - SASL Quality of Protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
-/target/
+# Eclipse
 .classpath
 .project
 .settings/
+
+# IntelliJ IDEA
+.idea
+*.iml
+
+# bin
+/target/

--- a/lsc.episode
+++ b/lsc.episode
@@ -5,7 +5,7 @@
 Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-Généré le : 2014.05.15 à 05:01:12 PM CEST 
+Généré le : 2017.02.03 à 01:41:23 PM CET 
 
   -->
   <bindings scd="x-schema::tns" xmlns:tns="http://lsc-project.org/XSD/lsc-core-2.1.xsd">
@@ -15,14 +15,14 @@ Généré le : 2014.05.15 à 05:01:12 PM CEST
     <bindings scd="~tns:serviceType">
       <class ref="org.lsc.configuration.ServiceType"/>
     </bindings>
-    <bindings scd="~tns:keysValuesMap">
-      <class ref="org.lsc.configuration.KeysValuesMap"/>
-    </bindings>
     <bindings scd="~tns:multiDestinationServiceType">
       <class ref="org.lsc.configuration.MultiDestinationServiceType"/>
     </bindings>
     <bindings scd="~tns:taskType">
       <class ref="org.lsc.configuration.TaskType"/>
+    </bindings>
+    <bindings scd="~tns:keysValuesMap">
+      <class ref="org.lsc.configuration.KeysValuesMap"/>
     </bindings>
     <bindings scd="tns:lsc">
       <class ref="org.lsc.configuration.Lsc"/>
@@ -39,47 +39,44 @@ Généré le : 2014.05.15 à 05:01:12 PM CEST
     <bindings scd="~tns:securityType">
       <class ref="org.lsc.configuration.SecurityType"/>
     </bindings>
-    <bindings scd="~tns:databaseDestinationServiceType">
-      <class ref="org.lsc.configuration.DatabaseDestinationServiceType"/>
+    <bindings scd="~tns:pluginSyncOptionsType">
+      <class ref="org.lsc.configuration.PluginSyncOptionsType"/>
     </bindings>
-    <bindings scd="~tns:pluginDestinationServiceType">
-      <class ref="org.lsc.configuration.PluginDestinationServiceType"/>
+    <bindings scd="~tns:googleAppsConnectionType">
+      <class ref="org.lsc.configuration.GoogleAppsConnectionType"/>
     </bindings>
-    <bindings scd="~tns:valuesType">
-      <class ref="org.lsc.configuration.ValuesType"/>
+    <bindings scd="~tns:pluginConnectionType">
+      <class ref="org.lsc.configuration.PluginConnectionType"/>
     </bindings>
-    <bindings scd="~tns:ldapServiceType">
-      <class ref="org.lsc.configuration.LdapServiceType"/>
-    </bindings>
-    <bindings scd="~tns:ldifAuditType">
-      <class ref="org.lsc.configuration.LdifAuditType"/>
-    </bindings>
-    <bindings scd="~tns:ldapDestinationServiceType">
-      <class ref="org.lsc.configuration.LdapDestinationServiceType"/>
-    </bindings>
-    <bindings scd="~tns:ldapSourceServiceType">
-      <class ref="org.lsc.configuration.LdapSourceServiceType"/>
-    </bindings>
-    <bindings scd="~tns:databaseConnectionType">
-      <class ref="org.lsc.configuration.DatabaseConnectionType"/>
-    </bindings>
-    <bindings scd="~tns:googleAppsServiceType">
-      <class ref="org.lsc.configuration.GoogleAppsServiceType"/>
-    </bindings>
-    <bindings scd="~tns:propertiesBasedSyncOptionsType">
-      <class ref="org.lsc.configuration.PropertiesBasedSyncOptionsType"/>
+    <bindings scd="~tns:encryptionType">
+      <class ref="org.lsc.configuration.EncryptionType"/>
     </bindings>
     <bindings scd="~tns:auditType">
       <class ref="org.lsc.configuration.AuditType"/>
     </bindings>
-    <bindings scd="~tns:pluginAuditType">
-      <class ref="org.lsc.configuration.PluginAuditType"/>
+    <bindings scd="~tns:ldifAuditType">
+      <class ref="org.lsc.configuration.LdifAuditType"/>
+    </bindings>
+    <bindings scd="~tns:connectionType">
+      <class ref="org.lsc.configuration.ConnectionType"/>
     </bindings>
     <bindings scd="~tns:pluginSourceServiceType">
       <class ref="org.lsc.configuration.PluginSourceServiceType"/>
     </bindings>
-    <bindings scd="~tns:googleAppsConnectionType">
-      <class ref="org.lsc.configuration.GoogleAppsConnectionType"/>
+    <bindings scd="~tns:xaFileDestinationServiceType">
+      <class ref="org.lsc.configuration.XaFileDestinationServiceType"/>
+    </bindings>
+    <bindings scd="~tns:pluginDestinationServiceType">
+      <class ref="org.lsc.configuration.PluginDestinationServiceType"/>
+    </bindings>
+    <bindings scd="~tns:conditionsType">
+      <class ref="org.lsc.configuration.ConditionsType"/>
+    </bindings>
+    <bindings scd="~tns:databaseSourceServiceType">
+      <class ref="org.lsc.configuration.DatabaseSourceServiceType"/>
+    </bindings>
+    <bindings scd="~tns:googleAppsServiceType">
+      <class ref="org.lsc.configuration.GoogleAppsServiceType"/>
     </bindings>
     <bindings scd="~tns:asyncLdapSourceServiceType">
       <class ref="org.lsc.configuration.AsyncLdapSourceServiceType"/>
@@ -90,41 +87,38 @@ Généré le : 2014.05.15 à 05:01:12 PM CEST
     <bindings scd="~tns:datasetType">
       <class ref="org.lsc.configuration.DatasetType"/>
     </bindings>
-    <bindings scd="~tns:pluginSyncOptionsType">
-      <class ref="org.lsc.configuration.PluginSyncOptionsType"/>
+    <bindings scd="~tns:ldapDestinationServiceType">
+      <class ref="org.lsc.configuration.LdapDestinationServiceType"/>
     </bindings>
-    <bindings scd="~tns:csvAuditType">
-      <class ref="org.lsc.configuration.CsvAuditType"/>
-    </bindings>
-    <bindings scd="~tns:connectionType">
-      <class ref="org.lsc.configuration.ConnectionType"/>
-    </bindings>
-    <bindings scd="~tns:databaseSourceServiceType">
-      <class ref="org.lsc.configuration.DatabaseSourceServiceType"/>
-    </bindings>
-    <bindings scd="~tns:encryptionType">
-      <class ref="org.lsc.configuration.EncryptionType"/>
-    </bindings>
-    <bindings scd="~tns:pluginConnectionType">
-      <class ref="org.lsc.configuration.PluginConnectionType"/>
+    <bindings scd="~tns:propertiesBasedSyncOptionsType">
+      <class ref="org.lsc.configuration.PropertiesBasedSyncOptionsType"/>
     </bindings>
     <bindings scd="~tns:syncOptionsType">
       <class ref="org.lsc.configuration.SyncOptionsType"/>
     </bindings>
-    <bindings scd="~tns:conditionsType">
-      <class ref="org.lsc.configuration.ConditionsType"/>
+    <bindings scd="~tns:ldapServiceType">
+      <class ref="org.lsc.configuration.LdapServiceType"/>
     </bindings>
-    <bindings scd="~tns:xaFileDestinationServiceType">
-      <class ref="org.lsc.configuration.XaFileDestinationServiceType"/>
+    <bindings scd="~tns:valuesType">
+      <class ref="org.lsc.configuration.ValuesType"/>
     </bindings>
     <bindings scd="~tns:forceSyncOptionsType">
       <class ref="org.lsc.configuration.ForceSyncOptionsType"/>
     </bindings>
-    <bindings scd="~tns:googleAppsProvisioningType">
-      <typesafeEnumClass ref="org.lsc.configuration.GoogleAppsProvisioningType"/>
+    <bindings scd="~tns:databaseConnectionType">
+      <class ref="org.lsc.configuration.DatabaseConnectionType"/>
     </bindings>
-    <bindings scd="~tns:ldapDerefAliasesType">
-      <typesafeEnumClass ref="org.lsc.configuration.LdapDerefAliasesType"/>
+    <bindings scd="~tns:ldapSourceServiceType">
+      <class ref="org.lsc.configuration.LdapSourceServiceType"/>
+    </bindings>
+    <bindings scd="~tns:pluginAuditType">
+      <class ref="org.lsc.configuration.PluginAuditType"/>
+    </bindings>
+    <bindings scd="~tns:csvAuditType">
+      <class ref="org.lsc.configuration.CsvAuditType"/>
+    </bindings>
+    <bindings scd="~tns:databaseDestinationServiceType">
+      <class ref="org.lsc.configuration.DatabaseDestinationServiceType"/>
     </bindings>
     <bindings scd="~tns:ldapVersionType">
       <typesafeEnumClass ref="org.lsc.configuration.LdapVersionType"/>
@@ -132,14 +126,23 @@ Généré le : 2014.05.15 à 05:01:12 PM CEST
     <bindings scd="~tns:ldapReferralType">
       <typesafeEnumClass ref="org.lsc.configuration.LdapReferralType"/>
     </bindings>
-    <bindings scd="~tns:ldapServerType">
-      <typesafeEnumClass ref="org.lsc.configuration.LdapServerType"/>
+    <bindings scd="~tns:ldapDerefAliasesType">
+      <typesafeEnumClass ref="org.lsc.configuration.LdapDerefAliasesType"/>
+    </bindings>
+    <bindings scd="~tns:saslQopType">
+      <typesafeEnumClass ref="org.lsc.configuration.SaslQopType"/>
+    </bindings>
+    <bindings scd="~tns:ldapAuthenticationType">
+      <typesafeEnumClass ref="org.lsc.configuration.LdapAuthenticationType"/>
+    </bindings>
+    <bindings scd="~tns:googleAppsProvisioningType">
+      <typesafeEnumClass ref="org.lsc.configuration.GoogleAppsProvisioningType"/>
     </bindings>
     <bindings scd="~tns:policyType">
       <typesafeEnumClass ref="org.lsc.configuration.PolicyType"/>
     </bindings>
-    <bindings scd="~tns:ldapAuthenticationType">
-      <typesafeEnumClass ref="org.lsc.configuration.LdapAuthenticationType"/>
+    <bindings scd="~tns:ldapServerType">
+      <typesafeEnumClass ref="org.lsc.configuration.LdapServerType"/>
     </bindings>
   </bindings>
 </bindings>

--- a/src/main/java/org/lsc/configuration/AsyncLdapSourceServiceType.java
+++ b/src/main/java/org/lsc/configuration/AsyncLdapSourceServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/AuditType.java
+++ b/src/main/java/org/lsc/configuration/AuditType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/AuditsType.java
+++ b/src/main/java/org/lsc/configuration/AuditsType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/ConditionsType.java
+++ b/src/main/java/org/lsc/configuration/ConditionsType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/ConnectionType.java
+++ b/src/main/java/org/lsc/configuration/ConnectionType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 
@@ -51,10 +51,10 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
     "password"
 })
 @XmlSeeAlso({
-    DatabaseConnectionType.class,
     GoogleAppsConnectionType.class,
+    PluginConnectionType.class,
     LdapConnectionType.class,
-    PluginConnectionType.class
+    DatabaseConnectionType.class
 })
 public class ConnectionType {
 

--- a/src/main/java/org/lsc/configuration/ConnectionsType.java
+++ b/src/main/java/org/lsc/configuration/ConnectionsType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/CsvAuditType.java
+++ b/src/main/java/org/lsc/configuration/CsvAuditType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/DatabaseConnectionType.java
+++ b/src/main/java/org/lsc/configuration/DatabaseConnectionType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/DatabaseDestinationServiceType.java
+++ b/src/main/java/org/lsc/configuration/DatabaseDestinationServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/DatabaseSourceServiceType.java
+++ b/src/main/java/org/lsc/configuration/DatabaseSourceServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/DatasetType.java
+++ b/src/main/java/org/lsc/configuration/DatasetType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/EncryptionType.java
+++ b/src/main/java/org/lsc/configuration/EncryptionType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/ForceSyncOptionsType.java
+++ b/src/main/java/org/lsc/configuration/ForceSyncOptionsType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/GoogleAppsConnectionType.java
+++ b/src/main/java/org/lsc/configuration/GoogleAppsConnectionType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/GoogleAppsProvisioningType.java
+++ b/src/main/java/org/lsc/configuration/GoogleAppsProvisioningType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/GoogleAppsServiceType.java
+++ b/src/main/java/org/lsc/configuration/GoogleAppsServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/KeysValuesMap.java
+++ b/src/main/java/org/lsc/configuration/KeysValuesMap.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdapAuthenticationType.java
+++ b/src/main/java/org/lsc/configuration/LdapAuthenticationType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdapConnectionType.java
+++ b/src/main/java/org/lsc/configuration/LdapConnectionType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 
@@ -35,6 +35,7 @@ import javax.xml.bind.annotation.XmlType;
  *         &lt;element name="sortedBy" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
  *         &lt;element name="binaryAttributes" type="{http://lsc-project.org/XSD/lsc-core-2.1.xsd}valuesType" minOccurs="0"/>
  *         &lt;element name="recursiveDelete" type="{http://www.w3.org/2001/XMLSchema}boolean" minOccurs="0"/>
+ *         &lt;element name="saslQop" type="{http://lsc-project.org/XSD/lsc-core-2.1.xsd}saslQopType" minOccurs="0"/>
  *       &lt;/sequence>
  *     &lt;/extension>
  *   &lt;/complexContent>
@@ -55,7 +56,8 @@ import javax.xml.bind.annotation.XmlType;
     "saslMutualAuthentication",
     "sortedBy",
     "binaryAttributes",
-    "recursiveDelete"
+    "recursiveDelete",
+    "saslQop"
 })
 public class LdapConnectionType
     extends ConnectionType
@@ -81,6 +83,8 @@ public class LdapConnectionType
     protected ValuesType binaryAttributes;
     @XmlElement(defaultValue = "false")
     protected Boolean recursiveDelete = false;
+    @XmlElement(defaultValue = "auth")
+    protected SaslQopType saslQop = SaslQopType.AUTH;
 
     /**
      * Obtient la valeur de la propriété authentication.
@@ -344,6 +348,30 @@ public class LdapConnectionType
      */
     public void setRecursiveDelete(Boolean value) {
         this.recursiveDelete = value;
+    }
+
+    /**
+     * Obtient la valeur de la propriété saslQop.
+     * 
+     * @return
+     *     possible object is
+     *     {@link SaslQopType }
+     *     
+     */
+    public SaslQopType getSaslQop() {
+        return saslQop;
+    }
+
+    /**
+     * Définit la valeur de la propriété saslQop.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link SaslQopType }
+     *     
+     */
+    public void setSaslQop(SaslQopType value) {
+        this.saslQop = value;
     }
 
 }

--- a/src/main/java/org/lsc/configuration/LdapDerefAliasesType.java
+++ b/src/main/java/org/lsc/configuration/LdapDerefAliasesType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdapDestinationServiceType.java
+++ b/src/main/java/org/lsc/configuration/LdapDestinationServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdapReferralType.java
+++ b/src/main/java/org/lsc/configuration/LdapReferralType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdapServerType.java
+++ b/src/main/java/org/lsc/configuration/LdapServerType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdapServiceType.java
+++ b/src/main/java/org/lsc/configuration/LdapServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdapSourceServiceType.java
+++ b/src/main/java/org/lsc/configuration/LdapSourceServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdapVersionType.java
+++ b/src/main/java/org/lsc/configuration/LdapVersionType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/LdifAuditType.java
+++ b/src/main/java/org/lsc/configuration/LdifAuditType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/Lsc.java
+++ b/src/main/java/org/lsc/configuration/Lsc.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/MultiDestinationServiceType.java
+++ b/src/main/java/org/lsc/configuration/MultiDestinationServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/ObjectFactory.java
+++ b/src/main/java/org/lsc/configuration/ObjectFactory.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 
@@ -45,14 +45,6 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link KeysValuesMap }
-     * 
-     */
-    public KeysValuesMap createKeysValuesMap() {
-        return new KeysValuesMap();
-    }
-
-    /**
      * Create an instance of {@link MultiDestinationServiceType }
      * 
      */
@@ -66,6 +58,14 @@ public class ObjectFactory {
      */
     public TaskType createTaskType() {
         return new TaskType();
+    }
+
+    /**
+     * Create an instance of {@link KeysValuesMap }
+     * 
+     */
+    public KeysValuesMap createKeysValuesMap() {
+        return new KeysValuesMap();
     }
 
     /**
@@ -109,75 +109,35 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link DatabaseDestinationServiceType }
+     * Create an instance of {@link PluginSyncOptionsType }
      * 
      */
-    public DatabaseDestinationServiceType createDatabaseDestinationServiceType() {
-        return new DatabaseDestinationServiceType();
+    public PluginSyncOptionsType createPluginSyncOptionsType() {
+        return new PluginSyncOptionsType();
     }
 
     /**
-     * Create an instance of {@link PluginDestinationServiceType }
+     * Create an instance of {@link GoogleAppsConnectionType }
      * 
      */
-    public PluginDestinationServiceType createPluginDestinationServiceType() {
-        return new PluginDestinationServiceType();
+    public GoogleAppsConnectionType createGoogleAppsConnectionType() {
+        return new GoogleAppsConnectionType();
     }
 
     /**
-     * Create an instance of {@link ValuesType }
+     * Create an instance of {@link PluginConnectionType }
      * 
      */
-    public ValuesType createValuesType() {
-        return new ValuesType();
+    public PluginConnectionType createPluginConnectionType() {
+        return new PluginConnectionType();
     }
 
     /**
-     * Create an instance of {@link LdifAuditType }
+     * Create an instance of {@link EncryptionType }
      * 
      */
-    public LdifAuditType createLdifAuditType() {
-        return new LdifAuditType();
-    }
-
-    /**
-     * Create an instance of {@link LdapDestinationServiceType }
-     * 
-     */
-    public LdapDestinationServiceType createLdapDestinationServiceType() {
-        return new LdapDestinationServiceType();
-    }
-
-    /**
-     * Create an instance of {@link LdapSourceServiceType }
-     * 
-     */
-    public LdapSourceServiceType createLdapSourceServiceType() {
-        return new LdapSourceServiceType();
-    }
-
-    /**
-     * Create an instance of {@link DatabaseConnectionType }
-     * 
-     */
-    public DatabaseConnectionType createDatabaseConnectionType() {
-        return new DatabaseConnectionType();
-    }
-
-    /**
-     * Create an instance of {@link GoogleAppsServiceType }
-     * 
-     */
-    public GoogleAppsServiceType createGoogleAppsServiceType() {
-        return new GoogleAppsServiceType();
-    }
-
-    /**
-     * Create an instance of {@link PropertiesBasedSyncOptionsType }
-     * 
-     */
-    public PropertiesBasedSyncOptionsType createPropertiesBasedSyncOptionsType() {
-        return new PropertiesBasedSyncOptionsType();
+    public EncryptionType createEncryptionType() {
+        return new EncryptionType();
     }
 
     /**
@@ -189,11 +149,19 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link PluginAuditType }
+     * Create an instance of {@link LdifAuditType }
      * 
      */
-    public PluginAuditType createPluginAuditType() {
-        return new PluginAuditType();
+    public LdifAuditType createLdifAuditType() {
+        return new LdifAuditType();
+    }
+
+    /**
+     * Create an instance of {@link ConnectionType }
+     * 
+     */
+    public ConnectionType createConnectionType() {
+        return new ConnectionType();
     }
 
     /**
@@ -205,11 +173,43 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link GoogleAppsConnectionType }
+     * Create an instance of {@link XaFileDestinationServiceType }
      * 
      */
-    public GoogleAppsConnectionType createGoogleAppsConnectionType() {
-        return new GoogleAppsConnectionType();
+    public XaFileDestinationServiceType createXaFileDestinationServiceType() {
+        return new XaFileDestinationServiceType();
+    }
+
+    /**
+     * Create an instance of {@link PluginDestinationServiceType }
+     * 
+     */
+    public PluginDestinationServiceType createPluginDestinationServiceType() {
+        return new PluginDestinationServiceType();
+    }
+
+    /**
+     * Create an instance of {@link ConditionsType }
+     * 
+     */
+    public ConditionsType createConditionsType() {
+        return new ConditionsType();
+    }
+
+    /**
+     * Create an instance of {@link DatabaseSourceServiceType }
+     * 
+     */
+    public DatabaseSourceServiceType createDatabaseSourceServiceType() {
+        return new DatabaseSourceServiceType();
+    }
+
+    /**
+     * Create an instance of {@link GoogleAppsServiceType }
+     * 
+     */
+    public GoogleAppsServiceType createGoogleAppsServiceType() {
+        return new GoogleAppsServiceType();
     }
 
     /**
@@ -237,67 +237,27 @@ public class ObjectFactory {
     }
 
     /**
-     * Create an instance of {@link PluginSyncOptionsType }
+     * Create an instance of {@link LdapDestinationServiceType }
      * 
      */
-    public PluginSyncOptionsType createPluginSyncOptionsType() {
-        return new PluginSyncOptionsType();
+    public LdapDestinationServiceType createLdapDestinationServiceType() {
+        return new LdapDestinationServiceType();
     }
 
     /**
-     * Create an instance of {@link CsvAuditType }
+     * Create an instance of {@link PropertiesBasedSyncOptionsType }
      * 
      */
-    public CsvAuditType createCsvAuditType() {
-        return new CsvAuditType();
+    public PropertiesBasedSyncOptionsType createPropertiesBasedSyncOptionsType() {
+        return new PropertiesBasedSyncOptionsType();
     }
 
     /**
-     * Create an instance of {@link ConnectionType }
+     * Create an instance of {@link ValuesType }
      * 
      */
-    public ConnectionType createConnectionType() {
-        return new ConnectionType();
-    }
-
-    /**
-     * Create an instance of {@link DatabaseSourceServiceType }
-     * 
-     */
-    public DatabaseSourceServiceType createDatabaseSourceServiceType() {
-        return new DatabaseSourceServiceType();
-    }
-
-    /**
-     * Create an instance of {@link EncryptionType }
-     * 
-     */
-    public EncryptionType createEncryptionType() {
-        return new EncryptionType();
-    }
-
-    /**
-     * Create an instance of {@link PluginConnectionType }
-     * 
-     */
-    public PluginConnectionType createPluginConnectionType() {
-        return new PluginConnectionType();
-    }
-
-    /**
-     * Create an instance of {@link ConditionsType }
-     * 
-     */
-    public ConditionsType createConditionsType() {
-        return new ConditionsType();
-    }
-
-    /**
-     * Create an instance of {@link XaFileDestinationServiceType }
-     * 
-     */
-    public XaFileDestinationServiceType createXaFileDestinationServiceType() {
-        return new XaFileDestinationServiceType();
+    public ValuesType createValuesType() {
+        return new ValuesType();
     }
 
     /**
@@ -309,19 +269,51 @@ public class ObjectFactory {
     }
 
     /**
+     * Create an instance of {@link DatabaseConnectionType }
+     * 
+     */
+    public DatabaseConnectionType createDatabaseConnectionType() {
+        return new DatabaseConnectionType();
+    }
+
+    /**
+     * Create an instance of {@link LdapSourceServiceType }
+     * 
+     */
+    public LdapSourceServiceType createLdapSourceServiceType() {
+        return new LdapSourceServiceType();
+    }
+
+    /**
+     * Create an instance of {@link PluginAuditType }
+     * 
+     */
+    public PluginAuditType createPluginAuditType() {
+        return new PluginAuditType();
+    }
+
+    /**
+     * Create an instance of {@link CsvAuditType }
+     * 
+     */
+    public CsvAuditType createCsvAuditType() {
+        return new CsvAuditType();
+    }
+
+    /**
+     * Create an instance of {@link DatabaseDestinationServiceType }
+     * 
+     */
+    public DatabaseDestinationServiceType createDatabaseDestinationServiceType() {
+        return new DatabaseDestinationServiceType();
+    }
+
+    /**
      * Create an instance of {@link ServiceType.Connection }
      * 
      */
     public ServiceType.Connection createServiceTypeConnection() {
         return new ServiceType.Connection();
-    }
-
-    /**
-     * Create an instance of {@link KeysValuesMap.Entry }
-     * 
-     */
-    public KeysValuesMap.Entry createKeysValuesMapEntry() {
-        return new KeysValuesMap.Entry();
     }
 
     /**
@@ -338,6 +330,14 @@ public class ObjectFactory {
      */
     public TaskType.AuditLog createTaskTypeAuditLog() {
         return new TaskType.AuditLog();
+    }
+
+    /**
+     * Create an instance of {@link KeysValuesMap.Entry }
+     * 
+     */
+    public KeysValuesMap.Entry createKeysValuesMapEntry() {
+        return new KeysValuesMap.Entry();
     }
 
 }

--- a/src/main/java/org/lsc/configuration/PluginAuditType.java
+++ b/src/main/java/org/lsc/configuration/PluginAuditType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/PluginConnectionType.java
+++ b/src/main/java/org/lsc/configuration/PluginConnectionType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/PluginDestinationServiceType.java
+++ b/src/main/java/org/lsc/configuration/PluginDestinationServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/PluginSourceServiceType.java
+++ b/src/main/java/org/lsc/configuration/PluginSourceServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/PluginSyncOptionsType.java
+++ b/src/main/java/org/lsc/configuration/PluginSyncOptionsType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/PolicyType.java
+++ b/src/main/java/org/lsc/configuration/PolicyType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/PropertiesBasedSyncOptionsType.java
+++ b/src/main/java/org/lsc/configuration/PropertiesBasedSyncOptionsType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/SecurityType.java
+++ b/src/main/java/org/lsc/configuration/SecurityType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/ServiceType.java
+++ b/src/main/java/org/lsc/configuration/ServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 
@@ -56,14 +56,14 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
     "connection"
 })
 @XmlSeeAlso({
-    DatabaseDestinationServiceType.class,
+    PluginSourceServiceType.class,
+    XaFileDestinationServiceType.class,
     PluginDestinationServiceType.class,
+    DatabaseSourceServiceType.class,
     GoogleAppsServiceType.class,
     MultiDestinationServiceType.class,
-    PluginSourceServiceType.class,
     LdapServiceType.class,
-    DatabaseSourceServiceType.class,
-    XaFileDestinationServiceType.class
+    DatabaseDestinationServiceType.class
 })
 public class ServiceType {
 

--- a/src/main/java/org/lsc/configuration/SyncOptionsType.java
+++ b/src/main/java/org/lsc/configuration/SyncOptionsType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 
@@ -41,8 +41,8 @@ import javax.xml.bind.annotation.XmlType;
     "mainIdentifier"
 })
 @XmlSeeAlso({
-    PropertiesBasedSyncOptionsType.class,
     PluginSyncOptionsType.class,
+    PropertiesBasedSyncOptionsType.class,
     ForceSyncOptionsType.class
 })
 public abstract class SyncOptionsType {

--- a/src/main/java/org/lsc/configuration/TaskType.java
+++ b/src/main/java/org/lsc/configuration/TaskType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/TasksType.java
+++ b/src/main/java/org/lsc/configuration/TasksType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/ValuesType.java
+++ b/src/main/java/org/lsc/configuration/ValuesType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/XaFileDestinationServiceType.java
+++ b/src/main/java/org/lsc/configuration/XaFileDestinationServiceType.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 

--- a/src/main/java/org/lsc/configuration/package-info.java
+++ b/src/main/java/org/lsc/configuration/package-info.java
@@ -2,7 +2,7 @@
 // Ce fichier a été généré par l'implémentation de référence JavaTM Architecture for XML Binding (JAXB), v2.2.6 
 // Voir <a href="http://java.sun.com/xml/jaxb">http://java.sun.com/xml/jaxb</a> 
 // Toute modification apportée à ce fichier sera perdue lors de la recompilation du schéma source. 
-// Généré le : 2014.05.15 à 05:01:12 PM CEST 
+// Généré le : 2017.02.03 à 01:41:23 PM CET 
 //
 
 @javax.xml.bind.annotation.XmlSchema(namespace = "http://lsc-project.org/XSD/lsc-core-2.1.xsd", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)

--- a/src/main/java/org/lsc/jndi/JndiServices.java
+++ b/src/main/java/org/lsc/jndi/JndiServices.java
@@ -45,16 +45,27 @@
  */
 package org.lsc.jndi;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import org.apache.commons.lang.StringUtils;
+import org.apache.directory.api.ldap.codec.api.ControlFactory;
+import org.apache.directory.api.ldap.codec.api.LdapApiService;
+import org.apache.directory.api.ldap.codec.api.LdapApiServiceFactory;
+import org.apache.directory.api.ldap.codec.controls.search.persistentSearch.PersistentSearchFactory;
+import org.apache.directory.api.ldap.extras.controls.syncrepl_impl.SyncStateValueFactory;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
+import org.apache.directory.api.ldap.model.exception.LdapURLEncodingException;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.name.Rdn;
+import org.apache.directory.api.ldap.model.url.LdapUrl;
+import org.lsc.Configuration;
+import org.lsc.LscDatasets;
+import org.lsc.configuration.LdapAuthenticationType;
+import org.lsc.configuration.LdapConnectionType;
+import org.lsc.configuration.LdapDerefAliasesType;
+import org.lsc.configuration.LdapReferralType;
+import org.lsc.configuration.LdapVersionType;
+import org.lsc.exception.LscConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.naming.CommunicationException;
 import javax.naming.Context;
@@ -87,28 +98,16 @@ import javax.security.auth.callback.PasswordCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.directory.api.ldap.codec.api.ControlFactory;
-import org.apache.directory.api.ldap.codec.api.LdapApiService;
-import org.apache.directory.api.ldap.codec.api.LdapApiServiceFactory;
-import org.apache.directory.api.ldap.codec.controls.search.persistentSearch.PersistentSearchFactory;
-import org.apache.directory.api.ldap.extras.controls.syncrepl_impl.SyncStateValueFactory;
-import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
-import org.apache.directory.api.ldap.model.exception.LdapURLEncodingException;
-import org.apache.directory.api.ldap.model.name.Dn;
-import org.apache.directory.api.ldap.model.name.Rdn;
-import org.apache.directory.api.ldap.model.url.LdapUrl;
-import org.lsc.Configuration;
-import org.lsc.LscDatasets;
-import org.lsc.configuration.LdapAuthenticationType;
-import org.lsc.configuration.LdapConnectionType;
-import org.lsc.configuration.LdapDerefAliasesType;
-import org.lsc.configuration.LdapReferralType;
-import org.lsc.configuration.LdapVersionType;
-import org.lsc.exception.LscConfigurationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 /**
  * General LDAP services wrapper.
@@ -354,6 +353,7 @@ public final class JndiServices {
 //				props.put("java.naming.security.sasl.authorizationId", "dn:" + connection.getUsername());
 				props.put("javax.security.auth.useSubjectCredsOnly", "true");
 				props.put("com.sun.jndi.ldap.trace.ber", System.err); //debug trace
+				props.setProperty("javax.security.sasl.qop", connection.getSaslQop().value());
 				try {
 					LoginContext lc = new LoginContext(JndiServices.class.getName(), new KerberosCallbackHandler(connection.getUsername(), connection.getPassword()));
 					lc.login();
@@ -409,6 +409,7 @@ public final class JndiServices {
         if(connection.isRecursiveDelete() != null) {
             props.setProperty("java.naming.recursivedelete", Boolean.toString(connection.isRecursiveDelete()));
         }
+
 		return props;
 	}
 	

--- a/src/main/resources/schemas/lsc-core-2.1.xsd
+++ b/src/main/resources/schemas/lsc-core-2.1.xsd
@@ -100,6 +100,14 @@
 			<xsd:enumeration value="VERSION_3" />
 		</xsd:restriction>
 	</xsd:simpleType>
+	
+	<xsd:simpleType name="saslQopType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="auth"/>
+			<xsd:enumeration value="auth-int"/>
+			<xsd:enumeration value="auth-conf"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 	<xsd:complexType name="ldapConnectionType">
 		<xsd:complexContent>
@@ -128,6 +136,8 @@
 						minOccurs="0" />
 					<xsd:element name="recursiveDelete" type="xsd:boolean"
 						default="false" minOccurs="0" />
+					<xsd:element name="saslQop" type="saslQopType"
+								 default="auth" minOccurs="0" />
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>


### PR DESCRIPTION
With Kerberos authentication, you may have to set the property _javax.security.sasl.qop_ in order to succeed authentication, depending of the security policy

This pull request includes : 

- Added a new optional element **saslQop** into lsc-core-2.1.xsd
- Added new line to JndiService to use this new setting

I did not add generated xjc class, maven will do in each build.

(Btw, I also added IntelliJ IDEA files in .gitignore)

