### PR TITLE
Prevent thead executor pool's queue to saturate when running large amount of sync entries

### DIFF
--- a/src/main/java/org/lsc/AbstractSynchronize.java
+++ b/src/main/java/org/lsc/AbstractSynchronize.java
@@ -319,26 +319,8 @@ public abstract class AbstractSynchronize {
 		 * Loop on all entries in the source and add or update them in the
 		 * destination
 		 */
-//		SynchronizeTask syncTask;
-		int threadCount = 0;
-		int threadPoolAwaitTerminationTimeOut = 900;
 		for (Entry<String, LscDatasets> id : ids) {
-//			syncTask = new SynchronizeTask(task, counter, this, id, true);
-//			syncTask.run();
-//			threadPool.runTask(new SynchronizeTask(task, counter, this, id, true));
 			threadPool.runTask(new SynchronizeTask(task, counter, this, id, true));
-			threadCount++;
-			if (threadCount == 10000) {
-				try {
-					threadPool.shutdown();
-					threadPool.awaitTermination(threadPoolAwaitTerminationTimeOut, TimeUnit.SECONDS);
-					threadCount = 0;
-					threadPool = null;
-					threadPool = new SynchronizeThreadPoolExecutor(getThreads());
-				} catch (InterruptedException e) {
-					LOGGER.error("Error while shutting down the threadpool and re initializing it: " + e.toString(), e);
-				}
-			}
 		}
 		try {
 			threadPool.shutdown();

--- a/src/main/java/org/lsc/SynchronizeThreadPoolExecutor.java
+++ b/src/main/java/org/lsc/SynchronizeThreadPoolExecutor.java
@@ -27,7 +27,7 @@ public class SynchronizeThreadPoolExecutor extends ThreadPoolExecutor {
 			.getLogger(SynchronizeThreadPoolExecutor.class);
 
 	protected SynchronizeThreadPoolExecutor(int threads) {
-		super(threads, Integer.MAX_VALUE, keepAliveTime, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(queueCapacity), new RejectedExecutionHandler() {
+		super(threads, threads, keepAliveTime, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(queueCapacity), new RejectedExecutionHandler() {
 			public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
 				// this will block if the queue is full
 				try {

--- a/src/main/java/org/lsc/SynchronizeThreadPoolExecutor.java
+++ b/src/main/java/org/lsc/SynchronizeThreadPoolExecutor.java
@@ -2,6 +2,7 @@ package org.lsc;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -17,6 +18,7 @@ import org.slf4j.LoggerFactory;
 public class SynchronizeThreadPoolExecutor extends ThreadPoolExecutor {
 
 	static long keepAliveTime = 60;
+	static int queueCapacity=10000;
 
 	BlockingQueue<Runnable> queue;
 
@@ -25,7 +27,18 @@ public class SynchronizeThreadPoolExecutor extends ThreadPoolExecutor {
 			.getLogger(SynchronizeThreadPoolExecutor.class);
 
 	protected SynchronizeThreadPoolExecutor(int threads) {
-		super(threads, Integer.MAX_VALUE, keepAliveTime, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(Configuration.MAX_CONCURRENT_SYNCHRONIZED));
+		super(threads, Integer.MAX_VALUE, keepAliveTime, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(queueCapacity), new RejectedExecutionHandler() {
+			public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+				// this will block if the queue is full
+				try {
+						executor.getQueue().put(r);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new RuntimeException(e);
+					}
+				}
+			}
+		);
 		queue = getQueue(); 
 	}
 


### PR DESCRIPTION
Fixes out of memory error by changing the way large thead executor pool's queue fills up when running large amount of sync entries. This proposed solution uses a rejectedExecution handler, instead of terminating threads 15 minutes after shutdown signal was sent. When adding a new thread to an already full queue, the run command will wait until there is space available in the queue for the new thread.

Fixes http://tools.lsc-project.org/issues/862
Fixes http://tools.lsc-project.org/issues/748
Related to http://tools.lsc-project.org/issues/742
Originally discussed in https://lists.lsc-project.org/pipermail/lsc-users/2013-August/001584.html

Credit : http://stackoverflow.com/a/10353250/7436404