### PR TITLE
add a structural objectClass to hsqldb sample root dn

### DIFF
--- a/sample/hsqldb/etc/test.ldif
+++ b/sample/hsqldb/etc/test.ldif
@@ -1,4 +1,5 @@
 dn: dc=lsc-project,dc=org
+objectClass: organization
 dc: lsc-project
 o: LSC Project
 objectClass: dcObject


### PR DESCRIPTION
Running the sample example triggers an error if no structural objectClass is provided in the LDIF file:

$ bin/lsc-sample --start-ldap-server
Starting LDAP server on ldap://localhost:33389/ ...
juin 27 14:34:40 - INFO  - Logging configuration successfully loaded from /home/johndoe/lsc/sample/hsqldb/bin/../etc/logback.xml 
juin 27 14:34:40 - INFO  - LSC configuration successfully loaded from /home/johndoe/lsc/sample/hsqldb/bin/../etc/
6205 [main] ERROR org.lsc.opendj.LdapServer - org.opends.server.util.LDIFException: Entry dc=lsc-project,dc=org read from LDIF starting at line 1 is not valid because it violates the server's schema configuration:  Entry dc=lsc-project,dc=org violates the Directory Server schema configuration because it does not include a structural objectclass.  All entries must contain a structural objectclass 
