### PR TITLE
Fix #40 async task connection reset after 15 minutes & fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 
 script: mvn -Popendj test -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 
 jdk:
   - oraclejdk8
-  - openjdk7
 
 script: mvn -Popendj test -B
 

--- a/src/main/java/org/lsc/service/SyncReplSourceService.java
+++ b/src/main/java/org/lsc/service/SyncReplSourceService.java
@@ -148,14 +148,14 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 	public static LdapAsyncConnection getConnection(LdapConnectionType ldapConn) throws LscServiceConfigurationException {
 		LdapUrl url;
 		try {
-            url = new LdapUrl(ldapConn.getUrl());
-            boolean isLdaps = "ldaps://".equalsIgnoreCase(url.getScheme());
-            int port = url.getPort();
-            if (port == -1) {
-            	port = isLdaps ? 636 : 389;
-            }
-            LdapAsyncConnection conn = new LdapNetworkConnection(url.getHost(), port);
-            LdapConnectionConfig lcc = conn.getConfig();
+			url = new LdapUrl(ldapConn.getUrl());
+			boolean isLdaps = "ldaps://".equalsIgnoreCase(url.getScheme());
+			int port = url.getPort();
+			if (port == -1) {
+				port = isLdaps ? 636 : 389;
+			}
+			LdapAsyncConnection conn = new LdapNetworkConnection(url.getHost(), port);
+			LdapConnectionConfig lcc = conn.getConfig();
 			lcc.setUseSsl(isLdaps);
 			lcc.setUseTls(ldapConn.isTlsActivated());
 			
@@ -179,14 +179,15 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 		} catch (LdapURLEncodingException e) {
 			throw new LscServiceConfigurationException(e.toString(), e);
 		} catch (LdapException e) {
-            throw new LscServiceConfigurationException(e.toString(), e);
-        } catch (NoSuchAlgorithmException e) {
-            throw new LscServiceConfigurationException(e.toString(), e);
+			throw new LscServiceConfigurationException(e.toString(), e);
+		} catch (NoSuchAlgorithmException e) {
+			throw new LscServiceConfigurationException(e.toString(), e);
 		} catch (KeyStoreException e) {
-            throw new LscServiceConfigurationException(e.toString(), e);
+			throw new LscServiceConfigurationException(e.toString(), e);
 		}
 	}
 	
+	@Override
 	public void close() throws IOException {
 		connection.close();
 	}
@@ -202,8 +203,8 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 		} catch (RuntimeException e) {
 			throw new LscServiceException(e.toString(), e);
 		} catch (LdapException e) {
-            throw new LscServiceException(e.toString(), e);
-        }
+			throw new LscServiceException(e.toString(), e);
+		}
 	}
 
 	/**
@@ -229,7 +230,7 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 			searchString = filterIdClean; 
 		}
 
-        searchString = Pattern.compile("\\{id\\}", Pattern.CASE_INSENSITIVE).matcher(searchString).replaceAll(Matcher.quoteReplacement(id));
+		searchString = Pattern.compile("\\{id\\}", Pattern.CASE_INSENSITIVE).matcher(searchString).replaceAll(Matcher.quoteReplacement(id));
 		if (pivotAttrs != null && pivotAttrs.getDatasets() != null && pivotAttrs.getDatasets().size() > 0) {
 			for (String attributeName : pivotAttrs.getAttributesNames()) {
 				String valueId = pivotAttrs.getValueForFilter(attributeName.toLowerCase());
@@ -243,26 +244,26 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 		}
 
 		try {
-		    EntryCursor entryCursor = null;
-            // When launching getBean in clean phase, the search base should be the Base DN, not the entry ID
-            String searchBaseDn = (fromSameService ? id : baseDn);
-            SearchScope searchScope = (fromSameService ? SearchScope.OBJECT : SearchScope.SUBTREE);
+			EntryCursor entryCursor = null;
+			// When launching getBean in clean phase, the search base should be the Base DN, not the entry ID
+			String searchBaseDn = (fromSameService ? id : baseDn);
+			SearchScope searchScope = (fromSameService ? SearchScope.OBJECT : SearchScope.SUBTREE);
 			if (!connection.isConnected()) {
 				connection = getConnection(ldapConn);
 			}
-            if(getAttrs() != null) {
+			if(getAttrs() != null) {
 				List<String> attrList = new ArrayList<String>(getAttrs());
 				attrList.addAll(pivotAttrs.getAttributesNames());
 				entryCursor = connection.search(searchBaseDn, searchString, searchScope, attrList.toArray(new String[attrList.size()]));
 			} else {
-			    entryCursor = connection.search(searchBaseDn, searchString, searchScope);
+				entryCursor = connection.search(searchBaseDn, searchString, searchScope);
 			}
 
 			srcBean = this.beanClass.newInstance();
 
 			entryCursor.next();
 			if(! entryCursor.available()) {
-			    return null;
+				return null;
 			}
 			Entry entry =  entryCursor.get();
 			// get dn
@@ -298,10 +299,10 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 				searchRequest.addAttributes(getAttrsId().toArray(new String[getAttrsId().size()]));
 				sf = getConnection(ldapConn).searchAsync(searchRequest);
 			} catch (LdapInvalidDnException e) {
-                throw new LscServiceException(e.toString(), e);
-            } catch (LdapException e) {
-                throw new LscServiceException(e.toString(), e);
-            }
+				throw new LscServiceException(e.toString(), e);
+			} catch (LdapException e) {
+				throw new LscServiceException(e.toString(), e);
+			}
 		}
 		Response searchResponse = null;
 		try {
@@ -318,13 +319,13 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 			temporaryMap.put(sre.getObjectName().toString(), convertEntry(sre.getEntry(), true));
 			return temporaryMap.entrySet().iterator().next();
 		} else if(searchResponse != null && searchResponse.getType() == MessageTypeEnum.SEARCH_RESULT_DONE){
-		    LdapResult result = ((SearchResultDone)searchResponse).getLdapResult();
-		    if(result.getResultCode() != ResultCodeEnum.SUCCESS) {
-		        throw new LscServiceCommunicationException(result.getDiagnosticMessage(), null);
-		    }
-		    sf = null;
+			LdapResult result = ((SearchResultDone)searchResponse).getLdapResult();
+			if(result.getResultCode() != ResultCodeEnum.SUCCESS) {
+				throw new LscServiceCommunicationException(result.getDiagnosticMessage(), null);
+			}
+			sf = null;
 		}
-        return null;
+		return null;
 	}
 
 	private boolean checkSearchResponse(Response searchResponse) {
@@ -332,7 +333,7 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 			return false;
 		}
 		
-        SyncStateValue syncStateCtrl = ( SyncStateValue ) searchResponse.getControl( SyncStateValue.OID );
+		SyncStateValue syncStateCtrl = ( SyncStateValue ) searchResponse.getControl( SyncStateValue.OID );
 		if (syncStateCtrl != null && syncStateCtrl.getSyncStateType() == SyncStateTypeEnum.DELETE) {
 			return false;
 		}
@@ -340,17 +341,17 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 		return true;
 	}
 
-    private AliasDerefMode getAlias(LdapDerefAliasesType aliasesHandling) {
+	private AliasDerefMode getAlias(LdapDerefAliasesType aliasesHandling) {
 		switch(aliasesHandling) {
 		case ALWAYS:
 			return AliasDerefMode.DEREF_ALWAYS;
 		case FIND:
-            return AliasDerefMode.DEREF_FINDING_BASE_OBJ;
+			return AliasDerefMode.DEREF_FINDING_BASE_OBJ;
 		case SEARCH:
-            return AliasDerefMode.DEREF_IN_SEARCHING;
+			return AliasDerefMode.DEREF_IN_SEARCHING;
 		case NEVER:
 		default:
-            return AliasDerefMode.NEVER_DEREF_ALIASES;
+			return AliasDerefMode.NEVER_DEREF_ALIASES;
 		}
 	}
 
@@ -358,18 +359,18 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 		switch(serverType) {
 		case OPEN_LDAP:
 		case APACHE_DS:
-		    DefaultLdapCodecService codec = new DefaultLdapCodecService();
-		    SyncRequestValueDecorator syncControl = new SyncRequestValueDecorator(codec);
-		    syncControl.setMode(SynchronizationModeEnum.REFRESH_AND_PERSIST);
-		    return syncControl;
+			DefaultLdapCodecService codec = new DefaultLdapCodecService();
+			SyncRequestValueDecorator syncControl = new SyncRequestValueDecorator(codec);
+			syncControl.setMode(SynchronizationModeEnum.REFRESH_AND_PERSIST);
+			return syncControl;
 		case OPEN_DS:
 		case OPEN_DJ:
 		case ORACLE_DS:
 		case SUN_DS:
 		case NETSCAPE_DS:
 		case NOVELL_E_DIRECTORY:
-		    PersistentSearchImpl searchControl = new PersistentSearchImpl();
-		    searchControl.setCritical(true);
+			PersistentSearchImpl searchControl = new PersistentSearchImpl();
+			searchControl.setCritical(true);
 			searchControl.setChangesOnly(true);
 			searchControl.setReturnECs(false);
 			searchControl.setChangeTypes(PersistentSearch.CHANGE_TYPES_MAX);

--- a/src/main/java/org/lsc/service/SyncReplSourceService.java
+++ b/src/main/java/org/lsc/service/SyncReplSourceService.java
@@ -194,6 +194,9 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 	@Override
 	public Map<String, LscDatasets> getListPivots() throws LscServiceException {
 		try {
+			if (!connection.isConnected()) {
+				connection = getConnection(ldapConn);
+			}
 			return convertSearchEntries(connection.search(getBaseDn(), getFilterAll(), SearchScope.SUBTREE,
 					getAttrsId().toArray(new String[getAttrsId().size()])));
 		} catch (RuntimeException e) {
@@ -244,7 +247,10 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
             // When launching getBean in clean phase, the search base should be the Base DN, not the entry ID
             String searchBaseDn = (fromSameService ? id : baseDn);
             SearchScope searchScope = (fromSameService ? SearchScope.OBJECT : SearchScope.SUBTREE);
-			if(getAttrs() != null) {
+			if (!connection.isConnected()) {
+				connection = getConnection(ldapConn);
+			}
+            if(getAttrs() != null) {
 				List<String> attrList = new ArrayList<String>(getAttrs());
 				attrList.addAll(pivotAttrs.getAttributesNames());
 				entryCursor = connection.search(searchBaseDn, searchString, searchScope, attrList.toArray(new String[attrList.size()]));


### PR DESCRIPTION
This fix re-connect to LDAP during async tasks if connection has timed out.

Currently, task connection is kept forever while running async check, potentially leading to lost connection errors after some times as it is only used when changes are detected :
* Lost connection error :
java.io.IOException: Connection reset by peer
at sun.nio.ch.FileDispatcherImpl.read0(Native Method) ~[na:1.8.0_151]
at sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:39) ~[na:1.8.0_151]
at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:223) ~[na:1.8.0_151]
at sun.nio.ch.IOUtil.read(IOUtil.java:197) ~[na:1.8.0_151]
at sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:380) ~[na:1.8.0_151]
at org.apache.mina.transport.socket.nio.NioProcessor.read(NioProcessor.java:273) ~[mina-core-2.0.7.jar:na]
at org.apache.mina.transport.socket.nio.NioProcessor.read(NioProcessor.java:44) ~[mina-core-2.0.7.jar:na]
at org.apache.mina.core.polling.AbstractPollingIoProcessor.read(AbstractPollingIoProcessor.java:690) [mina-core-2.0.7.jar:na]
at org.apache.mina.core.polling.AbstractPollingIoProcessor.process(AbstractPollingIoProcessor.java:664) [mina-core-2.0.7.jar:na]
at org.apache.mina.core.polling.AbstractPollingIoProcessor.process(AbstractPollingIoProcessor.java:653) [mina-core-2.0.7.jar:na]
at org.apache.mina.core.polling.AbstractPollingIoProcessor.access$600(AbstractPollingIoProcessor.java:67) [mina-core-2.0.7.jar:na]
at org.apache.mina.core.polling.AbstractPollingIoProcessor$Processor.run(AbstractPollingIoProcessor.java:1124) [mina-core-2.0.7.jar:na]
at org.apache.mina.util.NamePreservingRunnable.run(NamePreservingRunnable.java:64) [mina-core-2.0.7.jar:na]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_151]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_151]
at java.lang.Thread.run(Thread.java:748) [na:1.8.0_151]

* Following later by async task failure when data that need to be sync is pulled :
ERROR - LDAP error while reading entry CN=Test User,OU=Users,OU=ad-testing,DC=ad-testing,DC=test,DC=io (org.apache.directory.ldap.client.api.exception.InvalidConnectionException: Cannot connect on the server, the connection is invalid)
DEBUG - org.apache.directory.ldap.client.api.exception.InvalidConnectionException: Cannot connect on the server, the connection is invalid
org.apache.directory.ldap.client.api.exception.InvalidConnectionException: Cannot connect on the server, the connection is invalid
        at org.apache.directory.ldap.client.api.LdapNetworkConnection.checkSession(LdapNetworkConnection.java:271) ~[api-all-1.0.0-M22.jar:1.0.0-M22]
        at org.apache.directory.ldap.client.api.LdapNetworkConnection.searchAsync(LdapNetworkConnection.java:1667) ~[api-all-1.0.0-M22.jar:1.0.0-M22]
        at org.apache.directory.ldap.client.api.LdapNetworkConnection.search(LdapNetworkConnection.java:1710) ~[api-all-1.0.0-M22.jar:1.0.0-M22]
        at org.apache.directory.ldap.client.api.LdapNetworkConnection.search(LdapNetworkConnection.java:1603) ~[api-all-1.0.0-M22.jar:1.0.0-M22]
        at org.apache.directory.ldap.client.api.LdapNetworkConnection.search(LdapNetworkConnection.java:1613) ~[api-all-1.0.0-M22.jar:1.0.0-M22]
        at org.lsc.service.SyncReplSourceService.getBean(SyncReplSourceService.java:250) ~[lsc-core-2.1.4.jar:na]
        at org.lsc.SynchronizeTask.run(AbstractSynchronize.java:689) [lsc-core-2.1.4.jar:na]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_151]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_151]
        at java.lang.Thread.run(Thread.java:748) [na:1.8.0_151]

Fix detail : After changes are detected, and before changed entry is synchronized, connection.isConnected() is called; It returns the same result as the checkSession() method that throws the connection error (cf https://github.com/apache/directory-ldap-api/blob/2033a9dd83d89774744cc390ff1e5cf608a3d6dd/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapNetworkConnection.java#L262). If connection.isConnected() returns false, the connection is re-established.

Side remarks : LSC periodically checks for changes to apply (using syncrepl protocol) and seems to be reusing the same connection every time. But that connection doesn't times out since it is called every few seconds (see SyncReplSourceService.getNextId()), while the task connection is only used when an actual change is detected, which can lead to connection timing out.