### PR TITLE
Javascript feature to search attribute values

### DIFF
--- a/src/main/java/org/lsc/jndi/ScriptableJndiServices.java
+++ b/src/main/java/org/lsc/jndi/ScriptableJndiServices.java
@@ -48,6 +48,8 @@ package org.lsc.jndi;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import org.lsc.LscDatasets;
 
 import javax.naming.NamingException;
 import javax.naming.directory.SearchControls;
@@ -126,6 +128,55 @@ public class ScriptableJndiServices extends ScriptableObject {
 		return jndiServices.getDnList(base, filter, SearchControls.ONELEVEL_SCOPE);
 	}
 
+	
+        /**
+         * <P> Performs a search with subtree scope on a given base DN with a given
+         * filter returning attribute values </P>
+         * 
+         * @param base The base DN to search from.
+         * @param filter The LDAP filter to use.
+         * @attribute attribute The attribute to search.
+         * @return List<String> List of attributes values returned by the search.
+         * @throws NamingException
+         */
+        public final List<String> searchAttribute(final Object base, final Object filter, final Object attribute)
+    	    throws NamingException {
+    	return _searchAttribute((String) base, (String) filter, (String) attribute, SearchControls.SUBTREE_SCOPE);
+        }
+
+        /**
+         * <P> Performs a search with one level scope on a given base DN with a given
+         * filter returning attribute values </P>
+         *
+         * @param base The base DN to search from.
+         * @param filter The LDAP filter to use.
+         * @attribute attribute The attribute to search.
+         * @return List<String> List of attributes values returned by the search.
+         * @throws NamingException
+         */
+        public final List<String> listAttribute(final Object base, final Object filter, final Object attribute)
+    	    throws NamingException {
+    	return _searchAttribute((String) base, (String) filter, (String) attribute, SearchControls.ONELEVEL_SCOPE);
+        }
+
+    	protected List<String> _searchAttribute(final String base, final String filter, final String attribute,
+	    final int scope) throws NamingException {
+
+		List<String> resAttributes = new ArrayList<String>();
+
+		List<String> attrsNames = new ArrayList<String>();
+		attrsNames.add(attribute);
+
+		// Searching attributes values
+		Map<String, LscDatasets> res = jndiServices.getAttrsList(base, filter, scope, attrsNames);	
+ 
+		for (Map.Entry<String, LscDatasets> entry : res.entrySet()) {
+	    		resAttributes.add(entry.getValue().getStringValueAttribute(attribute));
+		}
+
+		return resAttributes;
+    	}
+	
 	/**
 	 * <P>Performs a search with base level scope on a given base DN with a given filter.</P>
 	 * 


### PR DESCRIPTION
Hello,

**Context** 
I'm using LSC to synchronize a LDAP eDirectory to a LDAP OpenDj.
The directories (source - target) haven't got the same structure.  So I had to write some javascript to build members attributes in my destination directory.
During tests, I faced performances issues with thousands source entries. 
Because my Javascript searched Dn with srcLdap.search queries and then for each dn searched a unique attribute value using  srcLdap.attribute.

**LSC changes**
I understood that if I can search directly unique attribute values using a new method  srcLdap.searchAttribute, performances will be improved.
So I developped new ScriptableJNDI services :
-searchAttribute : Performs a search with subtree scope on a given base DN with a given filter that returns attribute values.
-listAttribute : Performs a search with one level scope on a given base DN with a given filter that returns attribute values.

I think this new feature could benefit everyone.
So, I submit you the code for integration in lsc projet.
Let me now, if I need to refactor anything.

Thanks
Florian

