### PR TITLE
Fix on asynchronous mode with a Novell Edirectory source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -630,6 +630,17 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>xmlrpc</groupId>
+			<artifactId>xmlrpc</artifactId>
+			<version>3.0a1</version>
+		</dependency>
+		<dependency>
+			<groupId>xmlrpc</groupId>
+			<artifactId>xmlrpc-common</artifactId>
+			<version>3.0</version>
+		</dependency>
+		
+		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>1.4</version>
@@ -788,7 +799,7 @@
 		<dependency>
 			<groupId>org.apache.directory.api</groupId>
 			<artifactId>api-all</artifactId>
-			<version>1.0.0-M22</version>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>xml-apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -629,16 +629,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>xmlrpc</groupId>
-			<artifactId>xmlrpc</artifactId>
-			<version>3.0a1</version>
-		</dependency>
-		<dependency>
-			<groupId>xmlrpc</groupId>
-			<artifactId>xmlrpc-common</artifactId>
-			<version>3.0</version>
-		</dependency>
 		
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/src/main/java/org/lsc/jndi/JndiServices.java
+++ b/src/main/java/org/lsc/jndi/JndiServices.java
@@ -439,9 +439,9 @@ public final class JndiServices {
 	            return null;
 	        }
 	        if(fqdn.length() > 0) {
-	            fqdn = rdn.getNormValue().getString() + "." + fqdn;
+	            fqdn = rdn.getNormValue() + "." + fqdn;
 	        } else {
-	            fqdn = rdn.getNormValue().getString();
+	            fqdn = rdn.getNormValue();
 	        }
 	    }
 	    return fqdn;

--- a/src/main/java/org/lsc/service/SyncReplSourceService.java
+++ b/src/main/java/org/lsc/service/SyncReplSourceService.java
@@ -309,10 +309,6 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 			searchResponse = sf.get(1, TimeUnit.NANOSECONDS);
 		} catch (InterruptedException e) {
 			LOGGER.warn("Interrupted search !");
-		} catch (ExecutionException e) {
-			LOGGER.warn("Execution exception while searching !");
-		} catch (TimeoutException e) {
-			LOGGER.warn("Timeout during search !");
 		}
 		if(checkSearchResponse(searchResponse)) {
 			SearchResultEntryDecorator sre = ((SearchResultEntryDecorator) searchResponse);


### PR DESCRIPTION
Hello,

I found a bug working in asynchronous mode with a Novell Edirectory source.

Error is Unexpected DecoderException: The length of controls must not be null.
This bug is known on apache.directory.api (https://issues.apache.org/jira/browse/DIRAPI-295) and has been fixed in 1.0.0 version of org.apache.directory.api api-all.

So I decide to update api-all from 1.0.0-M22 to 1.0.0.
There is an impact in JndiServices and SyncReplSourceService classes. And the project has to run in JAVA 1.8.

Do you think this fix could be integrated to new lsc version ?

Thanks,
Florian