### PR TITLE
Fix Issue #62:

### DIFF
--- a/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
+++ b/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
@@ -99,7 +99,7 @@ public class JaxbXmlConfigurationHelper {
         String packagesName = Lsc.class.getPackage().getName();
         String pluginsPackagePath = System.getProperty("LSC.PLUGINS.PACKAGEPATH");
         if( pluginsPackagePath != null) {
-            packagesName = packagesName + ":" + pluginsPackagePath;
+            packagesName = packagesName + System.getProperty("path.separator") + pluginsPackagePath;
         }
         try {
             jaxbc = JAXBContext.newInstance( packagesName );


### PR DESCRIPTION
Configuring multiple plugin packages e.g

-DLSC.PLUGINS.PACKAGEPATH=foo.bar.plugins.configuration.file:foo.bar.plugins.configuration.ext

fails on Windows.

Fixes #62 