### PR TITLE
Fix NPE when job has two tasks with database destinations and sync op…

### DIFF
--- a/src/main/java/org/lsc/service/AbstractJdbcDstService.java
+++ b/src/main/java/org/lsc/service/AbstractJdbcDstService.java
@@ -124,20 +124,22 @@ public abstract class AbstractJdbcDstService extends AbstractJdbcService impleme
 
     @Override
     public List<String> getWriteDatasetIds() {
-        if(attributesNameCache != null && attributesNameCache.size() > 0) {
-            return attributesNameCache.get(serviceName);
+        List<String> writeDatasetIds = attributesNameCache.get(serviceName);
+        if(writeDatasetIds != null) {
+            return writeDatasetIds;
         }
-        attributesNameCache.put(serviceName, new ArrayList<String>());
+        writeDatasetIds = new ArrayList<String>();
         if(sqlMapper instanceof SqlMapClientImpl) {
             for(String request: getRequestsNameForInsert()) {
                 for(ParameterMapping pm : ((SqlMapClientImpl)sqlMapper).getDelegate().getMappedStatement(request).getParameterMap().getParameterMappings()) {
-                    attributesNameCache.get(serviceName).add(pm.getPropertyName());
+                    writeDatasetIds.add(pm.getPropertyName());
                 }
             }
+            attributesNameCache.put(serviceName, writeDatasetIds);
         } else {
             LOGGER.error("Unable to handle an unknown SQLMap Client type : " + sqlMapper.getClass().getName());
         }
-        return attributesNameCache.get(serviceName);
+        return writeDatasetIds;
     }
 
     public abstract List<String> getRequestsNameForInsert();


### PR DESCRIPTION

[lsc-test.zip](https://github.com/lsc-project/lsc/files/2287732/lsc-test.zip)
…tions

Null pointer thrown in job containing multiple tasks with database destinations and sync options. 

java.lang.NullPointerException: null
        at org.lsc.beans.syncoptions.PropertiesBasedSyncOptions.getDefaultValuedAttributeNames(PropertiesBasedSyncOptions.java:129) ~[bin/:na]
        at org.lsc.beans.BeanComparator.getWriteAttributes(BeanComparator.java:446) ~[bin/:na]
        at org.lsc.beans.BeanComparator.getUpdatedObject(BeanComparator.java:252) ~[bin/:na]
        at org.lsc.beans.BeanComparator.calculateModifications(BeanComparator.java:176) ~[bin/:na]
        at org.lsc.SynchronizeTask.run(AbstractSynchronize.java:755) [bin/:na]
        at org.lsc.SynchronizeTask.run(AbstractSynchronize.java:689) [bin/:na]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [na:1.8.0_161]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [na:1.8.0_161]
        at java.lang.Thread.run(Unknown Source) [na:1.8.0_161]

Test case attached 