### PR TITLE
Remove debug trace from GSSAPI code branch

### DIFF
--- a/src/main/java/org/lsc/jndi/JndiServices.java
+++ b/src/main/java/org/lsc/jndi/JndiServices.java
@@ -352,7 +352,6 @@ public final class JndiServices {
 				props.setProperty("javax.security.sasl.server.authentication", ""+connection.isSaslMutualAuthentication());
 //				props.put("java.naming.security.sasl.authorizationId", "dn:" + connection.getUsername());
 				props.put("javax.security.auth.useSubjectCredsOnly", "true");
-				props.put("com.sun.jndi.ldap.trace.ber", System.err); //debug trace
 				props.setProperty("javax.security.sasl.qop", connection.getSaslQop().value());
 				try {
 					LoginContext lc = new LoginContext(JndiServices.class.getName(), new KerberosCallbackHandler(connection.getUsername(), connection.getPassword()));


### PR DESCRIPTION
A debug instruction was forgotten in the GSSAPI code. This caused
increased CPU load and a lot of clutter when running LSC from a shell