### PR TITLE
Fix logback rotation file path

### DIFF
--- a/etc/logback.xml
+++ b/etc/logback.xml
@@ -2,6 +2,8 @@
 
 <configuration>
 
+	<property name="logdir" value="/tmp/lsc/log" />
+
 	<!-- Standard output to console -->
 	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
@@ -14,7 +16,7 @@
 	<!-- Log all application messages -->
 	<!-- this file is rotated every 10000KB, compressed and 7 files are kept for history -->
 	<appender name="LSC" class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<file>/tmp/lsc/log/lsc.log</file>
+		<file>${logdir}/lsc.log</file>
 
 		<layout class="org.lsc.utils.output.LdifLayout">
 			<Pattern>%date{MMM dd HH:mm:ss} - %-5level - %message%n</Pattern>
@@ -25,7 +27,7 @@
 		</filter>
 
 		<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-			<FileNamePattern>lsc.log.%i.gz</FileNamePattern>
+			<FileNamePattern>${logdir}/lsc.log.%i.gz</FileNamePattern>
 			<MinIndex>1</MinIndex>
 			<MaxIndex>7</MaxIndex>
 		</rollingPolicy>
@@ -40,7 +42,7 @@
 	<!-- this file is erased at each execution -->
 	<appender name="LSC_STATUS" class="ch.qos.logback.core.FileAppender">
 		<append>false</append>
-		<file>/tmp/lsc/log/lsc.status</file>
+		<file>${logdir}/lsc.status</file>
 
 		<layout class="org.lsc.utils.output.LdifLayout">
 			<Pattern>%date{MMM dd HH:mm:ss} - %-5level - %message%n</Pattern>
@@ -54,7 +56,7 @@
 	<!-- Special logger to have a LDIF file of all modifications applied -->
 	<!-- this file is rotated every 10000KB, compressed and 7 files are kept for history -->
 	<appender name="LDIF" class="ch.qos.logback.core.rolling.RollingFileAppender">
-		<file>/tmp/lsc/log/lsc.ldif</file>
+		<file>${logdir}/lsc.ldif</file>
 
 		<layout class="org.lsc.utils.output.LdifLayout">
 			<Pattern>%m%n</Pattern>
@@ -66,7 +68,7 @@
 		</filter>
 
 		<rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-			<FileNamePattern>lsc.ldif.%i.gz</FileNamePattern>
+			<FileNamePattern>${logdir}/lsc.ldif.%i.gz</FileNamePattern>
 			<MinIndex>1</MinIndex>
 			<MaxIndex>7</MaxIndex>
 		</rollingPolicy>


### PR DESCRIPTION
The default logback configuration file stored rotated .gz files in the
working directory, instead of storing them in /var/log/lsc