### PR TITLE
sort xsd files list

### DIFF
--- a/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
+++ b/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
@@ -142,7 +142,7 @@ public class JaxbXmlConfigurationHelper {
                 Set<String> xsdFiles = reflections.getResources(Pattern.compile(".*\\.xsd"));
                 Source[] schemasSource = new Source[xsdFiles.size()];
                 List<String> xsdFilesList = new ArrayList<String>(xsdFiles);
-                Collections.reverse(xsdFilesList);
+                Collections.sort(xsdFilesList, new XsdForLscComparator());
                 for(String schemaFile: xsdFilesList) {
                     LOGGER.debug("Importing XML schema file: " + schemaFile);
                     InputStream schemaStream = this.getClass().getClassLoader().getResourceAsStream(schemaFile);

--- a/src/main/java/org/lsc/configuration/XsdForLscComparator.java
+++ b/src/main/java/org/lsc/configuration/XsdForLscComparator.java
@@ -1,0 +1,63 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ * 
+ * Copyright (c) 2008 - 2011 LSC Project 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ *               (c) 2008 - 2011 LSC Project
+ *         Sebastien Bahloul <seb@lsc-project.org>
+ *         Thomas Chemineau <thomas@lsc-project.org>
+ *         Jonathan Clarke <jon@lsc-project.org>
+ *         Remy-Christophe Schermesser <rcs@lsc-project.org>
+ ****************************************************************************
+ */
+package org.lsc.configuration;
+
+import java.util.Comparator;
+
+public class XsdForLscComparator implements Comparator<String> {
+	
+   private static final String CORE = "lsc-core";
+	
+	@Override
+	public int compare(String o1, String o2) {
+		if(o1.contains(CORE))
+			return Integer.MIN_VALUE;
+		if(o2.contains(CORE))
+			return Integer.MAX_VALUE;
+		
+		return o1.compareToIgnoreCase(o2);
+	}
+}

--- a/src/test/java/org/lsc/configuration/XsdForLscComparatorTest.java
+++ b/src/test/java/org/lsc/configuration/XsdForLscComparatorTest.java
@@ -1,0 +1,79 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ * 
+ * Copyright (c) 2008 - 2011 LSC Project 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ *               (c) 2008 - 2011 LSC Project
+ *         Sebastien Bahloul <seb@lsc-project.org>
+ *         Thomas Chemineau <thomas@lsc-project.org>
+ *         Jonathan Clarke <jon@lsc-project.org>
+ *         Remy-Christophe Schermesser <rcs@lsc-project.org>
+ ****************************************************************************
+ */
+package org.lsc.configuration;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+public class XsdForLscComparatorTest {
+
+	private static final String CORE="schemas/lsc-core-2.1.xsd";
+	private static final String BEFORE="schemas/a.xsd";
+	private static final String BEFORE_2="schemas/c.xsd";
+	private static final String AFTER="schemas/p.xsd";
+	private static final String AFTER_2="schemas/z.xsd";
+	private static final ImmutableList<String> unsortedList = ImmutableList.of(AFTER, BEFORE_2, CORE, AFTER_2, BEFORE);
+	
+	@Test
+	public void sortedListShouldHaveCoreAsFirstElementThenBeSortedAlphabetically() {
+		ImmutableList<String> unsortedList = ImmutableList.of(AFTER, BEFORE_2, CORE, AFTER_2, BEFORE);
+		
+		List<String> sortedList = new ArrayList<String>(unsortedList);
+		Collections.sort(sortedList, new XsdForLscComparator());
+		
+		ImmutableList<String> expectedResult = ImmutableList.of(CORE, BEFORE, BEFORE_2, AFTER, AFTER_2);
+		
+		assertEquals(expectedResult, sortedList);	
+	}
+	
+}


### PR DESCRIPTION
For the moment the list of xsd files is loaded in the reverse order of  their hash.
so `lsc-openpaas-plugin-1.0.xsd` will be loaded after `schemas/lsc-core-2.1.xsd`
but  `lsc-james-plugin-1.0.xsd` will be loaded before and the call to ` schemaFactory.newSchema` will fail with a `SAXException` as the definitions in lsc core are required in the plugin schema.

The hash is not easily determinable and is an implementation details which is not desirable.
For example `lsc-james0-plugin-1.0.xsd`  is loaded in the correct order but is not `lsc-james-plugin-1.0.xsd`.

There is also a risk to change the order of the hashes of the core and the plugin by incrementing the version of the files.

This proposal aims to always load the core xsd first then the others in alphabetical order.
