### PR TITLE
Replace existing address no.such.host by a non existing one (for now?)

### DIFF
--- a/src/test/java/org/lsc/utils/directory/LDAPTest.java
+++ b/src/test/java/org/lsc/utils/directory/LDAPTest.java
@@ -105,7 +105,7 @@ public class LDAPTest {
 	// this should fail with a can't connect exception
 	@Test(expected = NamingException.class)
 	public void testCanBindCantConnect() throws NamingException {
-		LDAP.canBind("ldap://no.such.host:33389/", "cn=Directory Manager", "public");
+		LDAP.canBind("ldap://no.such.host.really:33389/", "cn=Directory Manager", "public");
 	}
 
 	// this should fail with a NamingException (no such object)


### PR DESCRIPTION
`no.such.host` unfortunately is now a real address. It makes a test uselessly slow.