### PR TITLE
Make LSC compatible with JDK 11, remove compatibility with JDK 5, 6, 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 
 jdk:
   - openjdk8
+  - openjdk11
 
 script: mvn -Popendj test -B
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,33 +80,6 @@
 		<finalName>${project.artifactId}-${project.version}</finalName>
 
 		<plugins>
-		
-			<plugin>
-			<!-- 
-			Quickfix so the maven-jaxb2-plugin is JDK 8 compatible
-			See https://java.net/jira/browse/MAVEN_JAXB2_PLUGIN-80. 
-			Please remove this when jaxb plugins is upgraded to 0.9.0+
-			-->
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>properties-maven-plugin</artifactId>
-				<version>1.0-alpha-2</version>
-				<executions>
-					<execution>
-						<id>set-additional-system-properties</id>
-						<goals>
-							<goal>set-system-properties</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<properties>
-						<property>
-							<name>javax.xml.accessExternalSchema</name>
-							<value>file,http</value>
-						</property>
-					</properties>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -148,9 +121,13 @@
 				<configuration>
 					<show>public</show>
 					<quiet>true</quiet>
-					<links>
-						<link>http://download.oracle.com/javase/6/docs/api/</link>
-					</links>
+                    			<!-- workaround for https://bugs.openjdk.java.net/browse/JDK-8212233 -->
+                    			<javaApiLinks>
+                        			<property>
+                            				<name>foo</name>
+                            				<value>bar</value>
+                        			</property>
+                    			</javaApiLinks>
 				</configuration>
 				<executions>
 					<execution>
@@ -252,7 +229,7 @@
 			<plugin>
 				<groupId>org.jvnet.jaxb2.maven2</groupId>
 				<artifactId>maven-jaxb2-plugin</artifactId>
-				<version>0.8.3</version>
+				<version>0.14.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -280,6 +257,11 @@
 						<groupId>org.jvnet.jaxb2_commons</groupId>
 						<artifactId>jaxb2-default-value</artifactId>
 						<version>1.1</version>
+					</dependency>
+					<dependency>
+						<groupId>javax.activation</groupId>
+						<artifactId>activation</artifactId>
+						<version>1.1.1</version>
 					</dependency>
 				</dependencies>
 			</plugin>
@@ -396,46 +378,6 @@
 	</build>
 
 	<profiles>
-		<profile>
-			<id>jdk18</id>
-			<activation>
-				<jdk>1.8</jdk>
-			</activation>
-			<properties>
-				<!-- Quickfix for javadoc generation with jdk8. Please remove this after fixing html 
-				validation errors in javadoc commentary. -->
-				<javadoc.opts>-Xdoclint:none</javadoc.opts>
-				<bc-jdk-version>jdk16</bc-jdk-version>
-			</properties>
-		</profile>
-		<profile>
-			<id>jdk17</id>
-			<activation>
-				<jdk>1.7</jdk>
-			</activation>
-			<properties>
-				<bc-jdk-version>jdk16</bc-jdk-version>
-			</properties>
-		</profile>
-		<profile>
-			<id>jdk16</id>
-			<activation>
-				<jdk>1.6</jdk>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<properties>
-				<bc-jdk-version>jdk16</bc-jdk-version>
-			</properties>
-		</profile>
-		<profile>
-			<id>jdk15</id>
-			<activation>
-				<jdk>1.5</jdk>
-			</activation>
-			<properties>
-				<bc-jdk-version>jdk15</bc-jdk-version>
-			</properties>
-		</profile>
 		<profile>
 			<id>opendj</id>
 			<activation>
@@ -686,7 +628,7 @@
 		</dependency>
 		<dependency>
 			<groupId>bouncycastle</groupId>
-			<artifactId>bcprov-${bc-jdk-version}</artifactId>
+			<artifactId>bcprov-jdk16</artifactId>
 			<version>140</version>
 			<type>jar</type>
 			<optional>false</optional>
@@ -755,6 +697,26 @@
 			<version>1.1</version>
 		</dependency>
 		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
 			<groupId>net.java.xadisk</groupId>
 			<artifactId>xadisk</artifactId>
 			<version>1.1</version>
@@ -763,11 +725,6 @@
 			<groupId>javax.resource</groupId>
 			<artifactId>connector-api</artifactId>
 			<version>1.5</version>
-		</dependency>
-		<dependency>
-			<groupId>javaee</groupId>
-			<artifactId>javaee-api</artifactId>
-			<version>5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.btm</groupId>

--- a/src/main/java/org/lsc/utils/JScriptEvaluator.java
+++ b/src/main/java/org/lsc/utils/JScriptEvaluator.java
@@ -262,7 +262,7 @@ public final class JScriptEvaluator implements ScriptableEvaluator {
 		/* Allow to have shorter names for function in the package org.lsc.utils.directory */
 		String expressionImport =
                         "var version = java.lang.System.getProperty(\"java.version\");\n" +
-                        "if (version.startsWith(\"1.8.0\")) { load(\"nashorn:mozilla_compat.js\"); }\n" +
+                        "load(\"nashorn:mozilla_compat.js\");\n" +
                         "importPackage(org.lsc.utils.directory);\n" +
                         "importPackage(org.lsc.utils);\n" + expression;
 


### PR DESCRIPTION
The goal of this pull request is to make LSC (future 2.2 version) compatible with only supported Java version: 8 et 11.