### PR TITLE
Fixed javadoc generator warning error when building with maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 		<staging.dir>${project.build.directory}/staging</staging.dir>
 		<tapestry-release-version>5.2.5</tapestry-release-version>
 		<jmockit-version>0.999.11</jmockit-version>
+		<javadoc.opts>-Xdoclint:none</javadoc.opts>
 	</properties>
 
 	<build>


### PR DESCRIPTION
This PR restores the javadoc.opts property in pom.xml used for build with JVMs in version 8+ that was lost after  support for Java 11 was added.

It prevents maven build to fail with this error: 

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 8:33.389s
[INFO] Finished at: Tue Jan 14 10:25:58 CET 2020
[INFO] Final Memory: 39M/60M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.8:javadoc (default) on project lsc-core: An error has occurred in JavaDocs report generation:
[ERROR] Exit code: 1 - javadoc: warning - Multiple sources of package comments found for package "org.apache.commons.collections"
[ERROR] /home/builder/rpmbuild/BUILD/lsc-2.2.0/src/main/java/org/lsc/Configuration.java:166: warning: no description for @throws
[ERROR] * @throws LscConfigurationException
[ERROR] ^
[ERROR] /home/builder/rpmbuild/BUILD/lsc-2.2.0/src/main/java/org/lsc/Configuration.java:177: warning: no description for @throws
[ERROR] * @throws LscConfigurationException
```