### PR TITLE
Fixed packageName calculation with plugin packagepath on windows.

### DIFF
--- a/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
+++ b/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
@@ -99,7 +99,7 @@ public class JaxbXmlConfigurationHelper {
         String packagesName = Lsc.class.getPackage().getName();
         String pluginsPackagePath = System.getProperty("LSC.PLUGINS.PACKAGEPATH");
         if( pluginsPackagePath != null) {
-            packagesName = packagesName + System.getProperty("path.separator") + pluginsPackagePath;
+            packagesName = packagesName + ":" + pluginsPackagePath;
         }
         try {
             jaxbc = JAXBContext.newInstance( packagesName );

--- a/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
+++ b/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
@@ -131,7 +131,7 @@ public class JaxbXmlConfigurationHelper {
                 Set<URL> urls = new HashSet<URL>();
                 urls.addAll(ClasspathHelper.forPackage("org.lsc"));
                 if(System.getProperty("LSC.PLUGINS.PACKAGEPATH") != null) {
-                    String[] pathElements = System.getProperty("LSC.PLUGINS.PACKAGEPATH").split(System.getProperty("path.separator"));
+                    String[] pathElements = System.getProperty("LSC.PLUGINS.PACKAGEPATH").split(":");
                     for(String pathElement: pathElements) {
                         urls.addAll(ClasspathHelper.forPackage(pathElement));
                     }


### PR DESCRIPTION
Even on Windows the package path for the JAXBContext uses a colon. So concatenation with 'System.getProperty("path.separator")' does not work in windows systems.