### PR TITLE
Fix package path calculation and use always colon as separator even on Windows.

### DIFF
--- a/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
+++ b/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
@@ -99,7 +99,7 @@ public class JaxbXmlConfigurationHelper {
         String packagesName = Lsc.class.getPackage().getName();
         String pluginsPackagePath = System.getProperty("LSC.PLUGINS.PACKAGEPATH");
         if( pluginsPackagePath != null) {
-            packagesName = packagesName + System.getProperty("path.separator") + pluginsPackagePath;
+            packagesName = packagesName + ":" + pluginsPackagePath;
         }
         try {
             jaxbc = JAXBContext.newInstance( packagesName );

--- a/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
+++ b/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
@@ -131,7 +131,7 @@ public class JaxbXmlConfigurationHelper {
                 Set<URL> urls = new HashSet<URL>();
                 urls.addAll(ClasspathHelper.forPackage("org.lsc"));
                 if(System.getProperty("LSC.PLUGINS.PACKAGEPATH") != null) {
-                    String[] pathElements = System.getProperty("LSC.PLUGINS.PACKAGEPATH").split(System.getProperty("path.separator"));
+                    String[] pathElements = System.getProperty("LSC.PLUGINS.PACKAGEPATH").split(":");
                     for(String pathElement: pathElements) {
                         urls.addAll(ClasspathHelper.forPackage(pathElement));
                     }

--- a/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
+++ b/src/main/java/org/lsc/configuration/JaxbXmlConfigurationHelper.java
@@ -87,6 +87,7 @@ public class JaxbXmlConfigurationHelper {
 
 	public static final String LSC_CONF_XML = "lsc.xml";
 	public static final String LSC_NAMESPACE = "http://lsc-project.org/XSD/lsc-core-2.0.xsd"; 
+	private static final String PACKAGEPATH_SEPARATOR = ":";
 	private JAXBContext jaxbc;
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(JaxbXmlConfigurationHelper.class);
@@ -99,7 +100,7 @@ public class JaxbXmlConfigurationHelper {
         String packagesName = Lsc.class.getPackage().getName();
         String pluginsPackagePath = System.getProperty("LSC.PLUGINS.PACKAGEPATH");
         if( pluginsPackagePath != null) {
-            packagesName = packagesName + ":" + pluginsPackagePath;
+            packagesName = packagesName + PACKAGEPATH_SEPARATOR + pluginsPackagePath;
         }
         try {
             jaxbc = JAXBContext.newInstance( packagesName );
@@ -131,7 +132,7 @@ public class JaxbXmlConfigurationHelper {
                 Set<URL> urls = new HashSet<URL>();
                 urls.addAll(ClasspathHelper.forPackage("org.lsc"));
                 if(System.getProperty("LSC.PLUGINS.PACKAGEPATH") != null) {
-                    String[] pathElements = System.getProperty("LSC.PLUGINS.PACKAGEPATH").split(":");
+                    String[] pathElements = System.getProperty("LSC.PLUGINS.PACKAGEPATH").split(PACKAGEPATH_SEPARATOR);
                     for(String pathElement: pathElements) {
                         urls.addAll(ClasspathHelper.forPackage(pathElement));
                     }


### PR DESCRIPTION
Found issues #62 and #65 where the separator was made consistent but the chosen separator 'System.getProperty("path.separator")' does not work on Windows.
The separator must be a colon. On Windows the "path.separator" is a semi colon.