### PR TITLE
Fixed: Wrong error message is displayed #137

### DIFF
--- a/src/main/java/org/lsc/jndi/JndiServices.java
+++ b/src/main/java/org/lsc/jndi/JndiServices.java
@@ -464,7 +464,7 @@ public final class JndiServices {
 		try {
 			return getInstance(getLdapProperties(connection));
 		} catch (Exception e) {
-			LOGGER.error("Error opening the LDAP connection to the destination! (" + e.toString() + ")");
+			LOGGER.error("Error opening LDAP connection \"" + connection.getName() + "\" to " + connection.getUrl() + " (" + e.toString() + ")");
 			throw new RuntimeException(e);
 		}
 	}


### PR DESCRIPTION
Error message is misleading as the faulty connection could also be the source connection.
Since we don't know which connection is opened, this PR display the connection name and URL for easier debugging.