### PR TITLE
Bump groovy version from 1.7.0 to 2.4.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -783,7 +783,7 @@
 		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>1.7.0</version>
+			<version>2.4.21</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.directory.api</groupId>


### PR DESCRIPTION
LSC uses a very old version of groovy, this is a proposal to upgrade to v2.4.21.
v2.4.21 is the last version that is compatible with JDK 1.6 according to https://groovy.apache.org/download.html#requirements.
Test runs OK, no dependencies are added, and a quick sync test using basic groovy code runs fine.