### PR TITLE
Ad unicode pwd auto encode

### DIFF
--- a/src/main/java/org/lsc/utils/directory/AD.java
+++ b/src/main/java/org/lsc/utils/directory/AD.java
@@ -116,6 +116,19 @@ public class AD {
 	}
 
 	/**
+	 * Kept for legacy reason, don't use in any new development
+	 *
+	 * @deprecated UnicodePwd attribute is automatically encoded within ActiveDirectoryDstService
+	 *             this method does nothing
+	 *             to find actual encoding see #getUnicodePwdEncoded(String password)
+	 */
+	public static String getUnicodePwd(String password)  throws UnsupportedEncodingException {
+
+		// don't do anything
+		return password;
+	}
+
+	/**
 	 * Encode a password so that it can be updated in Active Directory
 	 * in the field unicodePwd.
 	 *
@@ -123,11 +136,12 @@ public class AD {
 	 * @return The value to write in AD's unicodePwd attribute
 	 * @throws UnsupportedEncodingException
 	 */
-	public static String getUnicodePwd(String password) throws UnsupportedEncodingException {
+	public static byte[] getUnicodePwdEncoded(String password)
+			throws UnsupportedEncodingException
+	{
 		String quotedPassword = "\"" + password + "\"";
-		return new String(quotedPassword.getBytes("UTF-16LE"));
+		return quotedPassword.getBytes("UTF-16LE");
 	}
-
 
 	/**
 	 * The Unix epoch (1 January 1970 00:00:00 UT) in AD's time format 

--- a/src/test/java/org/lsc/CommonLdapSyncTest.java
+++ b/src/test/java/org/lsc/CommonLdapSyncTest.java
@@ -67,7 +67,7 @@ import org.lsc.jndi.JndiServices;
  * synchronization between two branches of the local LDAP server, and should
  * perform 3 operations : 1 ADD, 1 MODRDN, 1 MODIFY. The
  * 
- * @author Jonathan Clarke &ltjonathan@phillipoux.net&gt;
+ * @author Jonathan Clarke &lt;jonathan@phillipoux.net&gt;
  */
 public class CommonLdapSyncTest {
 

--- a/src/test/java/org/lsc/SimpleSynchronizeTest.java
+++ b/src/test/java/org/lsc/SimpleSynchronizeTest.java
@@ -59,7 +59,7 @@ import org.lsc.configuration.LscConfiguration;
  * 
  * Mostly sanity checks for the moment.
  * 
- * @author Jonathan Clarke &ltjonathan@phillipoux.net&gt;
+ * @author Jonathan Clarke &lt;jonathan@phillipoux.net&gt;
  */
 public class SimpleSynchronizeTest {
 

--- a/src/test/java/org/lsc/utils/directory/ADTest.java
+++ b/src/test/java/org/lsc/utils/directory/ADTest.java
@@ -1,180 +1,66 @@
-/*
- ****************************************************************************
- * Ldap Synchronization Connector provides tools to synchronize
- * electronic identities from a list of data sources including
- * any database with a JDBC connector, another LDAP directory,
- * flat files...
- *
- *                  ==LICENSE NOTICE==
- * 
- * Copyright (c) 2008 - 2011 LSC Project 
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
-
- *    * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
- *     * Neither the name of the LSC Project nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
- * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
- * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- *                  ==LICENSE NOTICE==
- *
- *               (c) 2008 - 2011 LSC Project
- *         Sebastien Bahloul <seb@lsc-project.org>
- *         Thomas Chemineau <thomas@lsc-project.org>
- *         Jonathan Clarke <jon@lsc-project.org>
- *         Remy-Christophe Schermesser <rcs@lsc-project.org>
- ****************************************************************************
- */
 package org.lsc.utils.directory;
 
-import java.util.Calendar;
-import java.util.TimeZone;
-
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import org.apache.commons.io.HexDump;
+
+import java.io.UnsupportedEncodingException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
 
 /**
- * Test AD specific function library.
+ * Test class to check org.lsc.utils.directory.AD implementation
  * 
- * @author Jonathan Clarke &lt;jon@lsc-project.org&gt;
+ *
  */
 public class ADTest {
 
-	// various representations of the reference date 01/10/08 8:12:34 UTC
-	private static Calendar refTimeCalendar;
-	private static final String refTimeADString = "128673223540000000";
-	private static final long refTimeADLong = 128673223540000000L;
-	private static final String refTimeUnixString = "1222848754";
-	private static final int refTimeUnixInt= 1222848754;
-	// representation of a date where Unix time need a long: Tue, 19 Jan 2038 03:14:10 GMT
-	private static final long otherTimeADLong = 137919572500000000L;
-	private static final long otherTimeUnixLong= 2147483650L;
 
-	@Before
-	public void setUp() {
-		refTimeCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-		refTimeCalendar.clear();
-		refTimeCalendar.set(2008, 10-1, 01, 8, 12, 34);
-	}
-	
-	/**
-	 * Test functions to manipulate AD's userAccountControl attribute in bit-field format.
-	 */
-	@Test
-	public final void testUserAccountControl() {
-		// initialize userAccountControl to a normal account
-		int uACValue = AD.userAccountControlSet(0, new String[]{AD.UAC_NORMAL_ACCOUNT.toString()});
-		assertEquals(512, uACValue);
-
-		// check it's enabled two ways
-		assertFalse(AD.userAccountControlCheck(uACValue, AD.UAC_ACCOUNTDISABLE.toString()));
-
-		// disable the account and set password expired
-		uACValue = AD.userAccountControlSet(uACValue, new String[]{AD.UAC_ACCOUNTDISABLE.toString(), AD.UAC_PASSWORD_EXPIRED.toString()});
-		assertEquals(8389122, uACValue);
-
-		// unset password expired
-		uACValue = AD.userAccountControlSet(uACValue, new String[]{AD.UAC_UNSET_PASSWORD_EXPIRED.toString()});
-		assertEquals(514, uACValue);
-
-		// check it's disabled
-		assertTrue(AD.userAccountControlCheck(uACValue, AD.UAC_ACCOUNTDISABLE.toString()));
-
-		// toggle it back to enabled
-		uACValue = AD.userAccountControlToggle(uACValue, AD.UAC_ACCOUNTDISABLE.toString());
-		assertEquals(512, uACValue);
-
-		// and toggle back to disabled
-		uACValue = AD.userAccountControlToggle(uACValue, AD.UAC_ACCOUNTDISABLE.toString());
-		assertEquals(514, uACValue);
+    	@Before
+	public void setup() {
+            // nothing to setup
 	}
 
-	/**
-	 * Test number of weeks calculation for lastLogon or lastLogonTimestamp attribute in AD.
-	 *
-	 * With this value:
-	 * lastLogonTimestamp: 128673223549843750
-	 * The last logon was recorded at 01/10/08 8:12:34 UTC.
-	 */
-	@Test
-	public final void testNumberWeeksLastLogon() {
-		// get result from tested class
-		int numWeeksFromLastLogon = AD.getNumberOfWeeksSinceLastLogon(refTimeADString);
+    	@Test
+	public void testGetUnicodePwd() throws Exception {
+            String inputPassword = "1aDhgtryjhddç";
+            String quotedPassword =  "\"" + inputPassword + "\"";
 
-		// calculate result from known date to now
-		Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-		long secondsSinceReference = (now.getTimeInMillis() - refTimeCalendar.getTimeInMillis()) / 1000;
-		int numWeeksFromReference = (int) (secondsSinceReference / (60 * 60 * 24 * 7));
+            System.out.println("Computed right UTF16-LE");
+            byte[] correct=quotedPassword.getBytes("UTF-16LE");
+            HexDump.dump(correct,0,System.out,0);
+           
 
-		assertTrue(numWeeksFromReference <= numWeeksFromLastLogon + 1 && numWeeksFromReference >= numWeeksFromLastLogon - 1);
-	}
-	
-	/**
-	 * Test for the {@link AD#aDTimeToUnixTimestamp(String)} method.
-	 */
-	@Test
-	public final void testADTimeToUnixTimestampWithString() {
-		Calendar testedTime = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-		testedTime.clear();
-		testedTime.setTimeInMillis(AD.aDTimeToUnixTimestamp(refTimeADString) * (long) 1000);
-		
-		assertEquals(refTimeCalendar, testedTime);
-	}
-	
-	/**
-	 * Test for the {@link AD#aDTimeToUnixTimestamp(long)} method.
-	 */
-	@Test
-	public final void testADTimeToUnixTimestampWithLong() {
-		Calendar testedTime = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-		testedTime.clear();
-		testedTime.setTimeInMillis(AD.aDTimeToUnixTimestamp(refTimeADLong) * (long) 1000);
-		
-		assertEquals(refTimeCalendar, testedTime);
-	}
+            // for reference
+            byte[] right = new byte[] {34,0,49,0,97,0,68,0,104,0,103,0,116,0,114,0,121,0,106,0,104,0,100,0,100,0,(byte) 0xe7,0,34,0};
+            // byte[] wrong = new byte[] {34,0,49,0,97,0,68,0,104,0,103,0,116,0,114,0,121,0,106,0,104,0,100,0,100,0,-17,-65,-67,0,34,0};
 
-	/**
-	 * Test for the {@link AD#unixTimestampToADTime(String)} method.
-	 */
-	@Test
-	public final void testUnixTimestampToADTimeWithString() {
-		assertEquals(refTimeADLong, AD.unixTimestampToADTime(refTimeUnixString));
-	}
-	
-	/**
-	 * Test for the {@link AD#unixTimestampToADTime(int)} method.
-	 */
-	@Test
-	public final void testUnixTimestampToADTimeWithInt() {
-		assertEquals(refTimeADLong, AD.unixTimestampToADTime(refTimeUnixInt));
-	}
-	
-	/**
-	 * Test for the {@link AD#unixTimestampToADTime(long)} method.
-	 */
-	@Test
-	public final void testUnixTimestampToADTimeWithLong() {
-		assertEquals(otherTimeADLong, AD.unixTimestampToADTime(otherTimeUnixLong));
-	}
-	
+            Assert.assertArrayEquals("INTERNAL failure wrong encoding", correct, right);
+
+            String outputPassword = AD.getUnicodePwd(inputPassword);
+            
+            System.out.println("Hardcoded right UTF16-LE");
+            HexDump.dump(right,0,System.out,0);
+
+            byte[] pwdArray=outputPassword.getBytes("ISO-8859-1");
+            System.out.println("current / via ISO-8859-1");
+            HexDump.dump(pwdArray,0,System.out,0);
+
+            // use default encoding
+            pwdArray=outputPassword.getBytes();
+            System.out.println("current / via default encoding");
+            HexDump.dump(pwdArray,0,System.out,0);
+            
+            Assert.assertArrayEquals("wrong encoding", pwdArray, right);
+            System.out.println("");
+        }	
+
 }

--- a/src/test/java/org/lsc/utils/directory/ADTest.java
+++ b/src/test/java/org/lsc/utils/directory/ADTest.java
@@ -46,19 +46,16 @@ public class ADTest {
             Assert.assertArrayEquals("INTERNAL failure wrong encoding", correct, right);
 
             String outputPassword = AD.getUnicodePwd(inputPassword);
+
+            assertEquals(outputPassword,inputPassword);
             
             System.out.println("Hardcoded right UTF16-LE");
             HexDump.dump(right,0,System.out,0);
 
-            byte[] pwdArray=outputPassword.getBytes("ISO-8859-1");
-            System.out.println("current / via ISO-8859-1");
+            byte[] pwdArray= AD.getUnicodePwdEncoded(inputPassword);
+            System.out.println("current");
             HexDump.dump(pwdArray,0,System.out,0);
 
-            // use default encoding
-            pwdArray=outputPassword.getBytes();
-            System.out.println("current / via default encoding");
-            HexDump.dump(pwdArray,0,System.out,0);
-            
             Assert.assertArrayEquals("wrong encoding", pwdArray, right);
             System.out.println("");
         }	

--- a/src/test/java/org/lsc/utils/directory/ADTest.java
+++ b/src/test/java/org/lsc/utils/directory/ADTest.java
@@ -1,10 +1,58 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ * 
+ * Copyright (c) 2008 - 2011 LSC Project 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ *               (c) 2008 - 2011 LSC Project
+ *         Sebastien Bahloul <seb@lsc-project.org>
+ *         Thomas Chemineau <thomas@lsc-project.org>
+ *         Jonathan Clarke <jon@lsc-project.org>
+ *         Remy-Christophe Schermesser <rcs@lsc-project.org>
+ ****************************************************************************
+ */
 package org.lsc.utils.directory;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 import org.apache.commons.io.HexDump;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
@@ -13,20 +61,129 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
 
 /**
- * Test class to check org.lsc.utils.directory.AD implementation
+ * Test AD specific function library.
  * 
- *
+ * @author Jonathan Clarke &lt;jon@lsc-project.org&gt;
  */
 public class ADTest {
 
+	// various representations of the reference date 01/10/08 8:12:34 UTC
+	private static Calendar refTimeCalendar;
+	private static final String refTimeADString = "128673223540000000";
+	private static final long refTimeADLong = 128673223540000000L;
+	private static final String refTimeUnixString = "1222848754";
+	private static final int refTimeUnixInt= 1222848754;
+	// representation of a date where Unix time need a long: Tue, 19 Jan 2038 03:14:10 GMT
+	private static final long otherTimeADLong = 137919572500000000L;
+	private static final long otherTimeUnixLong= 2147483650L;
 
-    	@Before
-	public void setup() {
-            // nothing to setup
+	@Before
+	public void setUp() {
+		refTimeCalendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+		refTimeCalendar.clear();
+		refTimeCalendar.set(2008, 10-1, 01, 8, 12, 34);
+	}
+	
+	/**
+	 * Test functions to manipulate AD's userAccountControl attribute in bit-field format.
+	 */
+	@Test
+	public final void testUserAccountControl() {
+		// initialize userAccountControl to a normal account
+		int uACValue = AD.userAccountControlSet(0, new String[]{AD.UAC_NORMAL_ACCOUNT.toString()});
+		assertEquals(512, uACValue);
+
+		// check it's enabled two ways
+		assertFalse(AD.userAccountControlCheck(uACValue, AD.UAC_ACCOUNTDISABLE.toString()));
+
+		// disable the account and set password expired
+		uACValue = AD.userAccountControlSet(uACValue, new String[]{AD.UAC_ACCOUNTDISABLE.toString(), AD.UAC_PASSWORD_EXPIRED.toString()});
+		assertEquals(8389122, uACValue);
+
+		// unset password expired
+		uACValue = AD.userAccountControlSet(uACValue, new String[]{AD.UAC_UNSET_PASSWORD_EXPIRED.toString()});
+		assertEquals(514, uACValue);
+
+		// check it's disabled
+		assertTrue(AD.userAccountControlCheck(uACValue, AD.UAC_ACCOUNTDISABLE.toString()));
+
+		// toggle it back to enabled
+		uACValue = AD.userAccountControlToggle(uACValue, AD.UAC_ACCOUNTDISABLE.toString());
+		assertEquals(512, uACValue);
+
+		// and toggle back to disabled
+		uACValue = AD.userAccountControlToggle(uACValue, AD.UAC_ACCOUNTDISABLE.toString());
+		assertEquals(514, uACValue);
+	}
+
+	/**
+	 * Test number of weeks calculation for lastLogon or lastLogonTimestamp attribute in AD.
+	 *
+	 * With this value:
+	 * lastLogonTimestamp: 128673223549843750
+	 * The last logon was recorded at 01/10/08 8:12:34 UTC.
+	 */
+	@Test
+	public final void testNumberWeeksLastLogon() {
+		// get result from tested class
+		int numWeeksFromLastLogon = AD.getNumberOfWeeksSinceLastLogon(refTimeADString);
+
+		// calculate result from known date to now
+		Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+		long secondsSinceReference = (now.getTimeInMillis() - refTimeCalendar.getTimeInMillis()) / 1000;
+		int numWeeksFromReference = (int) (secondsSinceReference / (60 * 60 * 24 * 7));
+
+		assertTrue(numWeeksFromReference <= numWeeksFromLastLogon + 1 && numWeeksFromReference >= numWeeksFromLastLogon - 1);
+	}
+	
+	/**
+	 * Test for the {@link AD#aDTimeToUnixTimestamp(String)} method.
+	 */
+	@Test
+	public final void testADTimeToUnixTimestampWithString() {
+		Calendar testedTime = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+		testedTime.clear();
+		testedTime.setTimeInMillis(AD.aDTimeToUnixTimestamp(refTimeADString) * (long) 1000);
+		
+		assertEquals(refTimeCalendar, testedTime);
+	}
+	
+	/**
+	 * Test for the {@link AD#aDTimeToUnixTimestamp(long)} method.
+	 */
+	@Test
+	public final void testADTimeToUnixTimestampWithLong() {
+		Calendar testedTime = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+		testedTime.clear();
+		testedTime.setTimeInMillis(AD.aDTimeToUnixTimestamp(refTimeADLong) * (long) 1000);
+		
+		assertEquals(refTimeCalendar, testedTime);
+	}
+
+	/**
+	 * Test for the {@link AD#unixTimestampToADTime(String)} method.
+	 */
+	@Test
+	public final void testUnixTimestampToADTimeWithString() {
+		assertEquals(refTimeADLong, AD.unixTimestampToADTime(refTimeUnixString));
+	}
+	
+	/**
+	 * Test for the {@link AD#unixTimestampToADTime(int)} method.
+	 */
+	@Test
+	public final void testUnixTimestampToADTimeWithInt() {
+		assertEquals(refTimeADLong, AD.unixTimestampToADTime(refTimeUnixInt));
+	}
+	
+	/**
+	 * Test for the {@link AD#unixTimestampToADTime(long)} method.
+	 */
+	@Test
+	public final void testUnixTimestampToADTimeWithLong() {
+		assertEquals(otherTimeADLong, AD.unixTimestampToADTime(otherTimeUnixLong));
 	}
 
     	@Test
@@ -43,10 +200,10 @@ public class ADTest {
             byte[] right = new byte[] {34,0,49,0,97,0,68,0,104,0,103,0,116,0,114,0,121,0,106,0,104,0,100,0,100,0,(byte) 0xe7,0,34,0};
             // byte[] wrong = new byte[] {34,0,49,0,97,0,68,0,104,0,103,0,116,0,114,0,121,0,106,0,104,0,100,0,100,0,-17,-65,-67,0,34,0};
 
-            Assert.assertArrayEquals("INTERNAL failure wrong encoding", correct, right);
+            assertArrayEquals("INTERNAL failure wrong encoding", correct, right);
 
             String outputPassword = AD.getUnicodePwd(inputPassword);
-
+            // confirm that  AD.getUnicodePwd is obsolete and does nothing.
             assertEquals(outputPassword,inputPassword);
             
             System.out.println("Hardcoded right UTF16-LE");
@@ -56,8 +213,7 @@ public class ADTest {
             System.out.println("current");
             HexDump.dump(pwdArray,0,System.out,0);
 
-            Assert.assertArrayEquals("wrong encoding", pwdArray, right);
+            assertArrayEquals("wrong encoding", pwdArray, right);
             System.out.println("");
         }	
-
 }


### PR DESCRIPTION
Tentative to encode password transparently when using ActiveDirectoryDstService.
- To test -
- 
AD.getUnicodePwd() does nothing anymore.