### PR TITLE
Use latest version of branch 2.x of maven-assembly-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.2-beta-5</version><!--$NO-MVN-MAN-VER$ -->
+				<version>2.6</version><!--$NO-MVN-MAN-VER$ -->
 				<configuration>
 					<descriptors>
 						<descriptor>src/main/assembly/dist.xml</descriptor>


### PR DESCRIPTION
This allow to benefit from https://issues.apache.org/jira/browse/MASSEMBLY-515 that currently prevent me from successfully building LSC on Linux.