### PR TITLE
Fix inaccurate log message when loading script engine

### DIFF
--- a/src/main/java/org/lsc/utils/ScriptingEvaluator.java
+++ b/src/main/java/org/lsc/utils/ScriptingEvaluator.java
@@ -43,15 +43,17 @@ public class ScriptingEvaluator {
 		instancesTypeCache = new HashMap<String, ScriptableEvaluator>();
 		List<ScriptEngineFactory> factories = mgr.getEngineFactories();
 		for (ScriptEngineFactory sef : factories) {
-			boolean loaded = true;
+			boolean loaded = false;
 			for (String name : sef.getNames()) {
 				if ("js".equals(name)) {
 					instancesTypeCache.put(name,
 							new JScriptEvaluator(sef.getScriptEngine()));
+					loaded = true;
 					break;
 				} else if ("groovy".equals(name)) {
 					instancesTypeCache.put("gr",
 							new GroovyEvaluator(sef.getScriptEngine()));
+					loaded = true;
 					break;
 				}
 				else if ("graal.js".equals(name)) {
@@ -60,10 +62,10 @@ public class ScriptingEvaluator {
 					 * ScriptEngineManager().getEngineByName("graal.js");
 					 * later.
 					 */
+					loaded = true;
 					break;
 
 				}
-				loaded = false;
 			}
 			if(!loaded) {
 				LOGGER.debug("Unsupported scripting engine: " + sef.getEngineName());


### PR DESCRIPTION
A script engine (e.g. "Oracle Nashorn") is incorrectly reported as unsupported in debug log message.

If we take as an example the "Oracle Nashorn" script engine, it has the following short names: nashorn, Nashorn, js, JS, JavaScript, javascript, ECMAScript, ecmascript.
With the current implementation, the script engine will be, by default, considered to be supported and if, while iterating on the list of short names, a short name is *not one of*: js, groovy, grall.js, the engine will be considered to be *not supported*. So with the example of "Oracle Nashorn" it will be reported as not supported event if one of its short name is `js` and it is actually loaded (the issue is only related to the log message).

This commit revert the logic: a script engine is by default unsupported and if one of its short names match one of js, groovy, grall.js it will be considered supported.