### PR TITLE
Fix maven-javadoc-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<staging.dir>${project.build.directory}/staging</staging.dir>
 		<jmockit-version>1.5</jmockit-version>
-		<javadoc.opts>-Xdoclint:none</javadoc.opts>
 		<graalvm.version>22.3.1</graalvm.version>
 		<compiler.dir>${project.build.directory}/compiler</compiler.dir>
 	</properties>
@@ -197,7 +196,7 @@
 							<goal>javadoc</goal>
 						</goals>
 						<configuration>
-							<additionalparam>${javadoc.opts}</additionalparam>
+							<doclint>none</doclint>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
According to documentation (`mvn help:describe -Dplugin=org.apache.maven.plugins:maven-javadoc-plugin:3.4.1 -Ddetail | grep additionalparam`), `additionalparam` is not a valid configuration parameter for `maven-javadoc-plugin`. This commit replace`additionalparam`  with `doclint`:
      Specifies specific checks to be performed on Javadoc comments.
      See [doclint](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#BEJEFABE).