### PR TITLE
Specify encoding to use for .properties files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>3.3.1</version>
 				<configuration>
-					<propertiesEncoding>ISO-8859-1</propertiesEncoding><!-- To avoid warning during plugin execution. The project currently doesn't include properties files. -->
+					<propertiesEncoding>UTF-8</propertiesEncoding><!-- To avoid warning during plugin execution. -->
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,14 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.3.1</version>
+				<configuration>
+					<propertiesEncoding>ISO-8859-1</propertiesEncoding><!-- To avoid warning during plugin execution. The project currently doesn't include properties files. -->
+				</configuration>
+			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
`maven-resources-plugin` is using `project.build.sourceEncoding` to specify encoding to use when copying filtered resources (see https://maven.apache.org/plugins/maven-resources-plugin/examples/encoding.html). `.properties` files are encoded in `ISO-8859-1` (see [Java 8 API documentation](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html), note that by default, since Java 9, Java runtime try to [read properties file as `UTF-8` encoded](https://docs.oracle.com/en/java/javase/11/intl/internationalization-enhancements1.html#GUID-974CF488-23E8-4963-A322-82006A7A14C7) en fallback to `ISO-8859-1` if needed). To prevent issue, `maven-resources-plugin` log a warning if encoding for `.properties` files is not specified in plugin configuration (see https://maven.apache.org/plugins/maven-resources-plugin/examples/filtering-properties-files.html).

This commit set the encoding to be used for `.properties` files to `ISO-8859-1`.

The purpose of this commit is solely to avoid a `maven-resources-plugin` as the project doesn't currently include `.properties` files.