### PR TITLE
Update izpack to 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,15 +251,16 @@
 			<plugin>
 				<groupId>org.codehaus.izpack</groupId>
 				<artifactId>izpack-maven-plugin</artifactId>
-				<version>1.0-alpha-5</version>
+				<version>5.2.1</version>
 
 				<!-- common configuration by all executions -->
 				<configuration>
-					<descriptor>${basedir}/src/install/install.xml</descriptor>
-					<descriptorEncoding>UTF-8</descriptorEncoding>
-					<fileExtension>jar</fileExtension>
-					<installerFile>${project.build.directory}/${project.artifactId}-${project.version}-installer.jar</installerFile>
-					<izpackBasedir>${project.build.directory}/${project.build.finalName}-dist/lsc-${project.version}</izpackBasedir>
+					<baseDir>${project.build.directory}/${project.build.finalName}-dist/lsc-${project.version}</baseDir>
+					<installFile>src/install/install.xml</installFile>
+					<mkdirs>true</mkdirs>
+					<finalName>${project.artifactId}-${project.version}-installer.jar</finalName>
+					<enableAttachArtifact>false</enableAttachArtifact>
+					<autoIncludeUrl>true</autoIncludeUrl>
 				</configuration>
 
 				<executions>

--- a/src/install/install.xml
+++ b/src/install/install.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 
-<installation version="1.0">
+<izpack:installation version="5.0"
+                     xmlns:izpack="http://izpack.org/schema/installation"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://izpack.org/schema/installation http://izpack.org/schema/5.0/izpack-installation-5.0.xsd">
 
 	<info>
 		<appname>${project.name}</appname>
 		<appversion>@{project.version}</appversion>
-		<appsubpath>LSC</appsubpath>
-		<url>@{project.url}</url>
 		<appsubpath>LSC</appsubpath>
 		<uninstaller name="uninstall.jar" path="${INSTALL_PATH}" write="yes" />
 		<javaversion>1.6</javaversion>
@@ -55,7 +56,7 @@
 	</panels>
 
 	<listeners>
-		<listener installer="SummaryLoggerInstallerListener">
+		<listener classname="SummaryLoggerInstallerListener" stage="install">
 			<os family="windows" />
 		</listener>
 	</listeners>
@@ -71,8 +72,10 @@
 		The native libraries to add. This is required for creating shortcuts
 		on Windows
 	-->
-	<native type="izpack" name="ShellLink.dll">
-		<os family="windows"/>
-	</native>
+	<natives>
+		<native type="izpack" name="ShellLink.dll">
+			<os family="windows"/>
+		</native>
+	</natives>
 
-</installation>
+</izpack:installation>


### PR DESCRIPTION
This fixes an issue when building with Java 14+
See https://openjdk.org/jeps/367

For whatever reason, `@{project.url}` is not expanded in ` src/install/install.xml]`, so it's commented out, but this needs to be fixed before this can be commited.