### PR TITLE
Use new ForgeRock repository URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -630,7 +630,7 @@
 		<repository>
                         <id>forgerock-community-repository</id>
                         <name>ForgeRock CommunityRepository</name>
-                        <url>https://maven.forgerock.org/repo/community</url>
+                        <url>https://maven.forgerock.org/artifactory/community</url>
                 </repository>
 		<repository>
 			<id>oracleReleases</id>


### PR DESCRIPTION
During the build I got the following error:
```
Could not transfer artifact org.forgerock.ce.opendj:opendj-server:pom:2.6.4 from/to forgerock-community-repository (https://maven.forgerock.org/repo/community): status code: 401, reason phrase:  (401)
```

According to https://backstage.forgerock.com/knowledge/kb/article/a53108595, ForgeRock URL changed from https://maven.forgerock.org/repo/ to https://maven.forgerock.org/artifactory/.

This pull request updates the pom.xml to use thes new URL.