### PR TITLE
Fix the JDK version range for jdk9 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
 		<profile>
 			<id>jdk9</id>
 			<activation>
-				<jdk>[9,11[</jdk>
+				<jdk>[9,11)</jdk>
 			</activation>
 			<properties>
 				<module.opts>--illegal-access=permit --add-reads java.base=java.logging</module.opts>


### PR DESCRIPTION
The version range was: `[9,11[`  leading to activation of `jdk9` profile when running on Java 11. This can be confirmed by running: `mvn help:active-profiles`. Actually `[9,11[` is not a valid range definition according to https://maven.apache.org/ref/3.9.5/maven-artifact/apidocs/org/apache/maven/artifact/versioning/VersionRange.html#createFromVersionSpec(java.lang.String) This change update the definition of version range to `[9,11)` that actually exclude Java 11 (`jdk11` will be activated in such situation).