### PR TITLE
Draft: Add java 17 in CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,3 +37,11 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B -Popendj package --file pom.xml
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B -Popendj package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'temurin'
@@ -30,7 +30,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B -Popendj package --file pom.xml
     - name: Set up JDK 8
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '8'
         distribution: 'temurin'


### PR DESCRIPTION
This does include the update to izpack from #243, which is needed for java 14+.
This is a draft, as I just want to check the CI with java 17 (and later with java 21).