### PR TITLE
Added setters & getters for lastSuccessfulSync

### DIFF
--- a/src/main/java/org/lsc/jndi/PullableJndiSrcService.java
+++ b/src/main/java/org/lsc/jndi/PullableJndiSrcService.java
@@ -163,4 +163,18 @@ public class PullableJndiSrcService extends SimpleJndiSrcService implements
 	public long getInterval() {
 		return interval*1000;
 	}
+
+	/**
+	* Getter for lastSuccessfulSync, useful in cases where the consumer has to work around this to reset this to zero for a forced fresh sync.
+	*/
+	public Date getLastSuccessfulSync() {
+		return this.lastSuccessfulSync;
+	}
+
+	/**
+	* Setter for lastSuccessfulSync, useful in cases where the consumer has to work around this to reset this to zero for a forced fresh sync.
+	*/
+	public void setLastSuccessfulSync(Date lastSuccessfulSync) {
+		this.lastSuccessfulSync = lastSuccessfulSync;
+	}
 }


### PR DESCRIPTION
We found that LSC syncs were spamming our services and explored governing the ```lastSuccessfulSync``` using the ```PullableJndiSrcService``` and that helped us to reduce the spam on service restarts. At a high-level, this is what we do:
- Maintain a copy of the lastSuccessfulSync from LSC on Service Shutdown as a configuration in our DB
- On the restart, the first thing to do would be pull the saved lastSuccessfulSync and set it back using the setter
- This happens just before the synchorizer kicks in 

Rough Use of this approach illustrated below:
```
final IService service = synchronize.getTask(PersonnelLdapSyncConfiguration.SYNC_TASK_NAME).getSourceService();
if(service instanceof PullableJndiSrcService) {
       PullableJndiSrcService srcService = (PullableJndiSrcService) service;
       Logger.log("LS1 = {0}", srcService.getLastSuccessfulSync());
       srcService.setLastSuccessfulSync(PersonnelLdapSyncConfiguration.getLastSuccessfulSync);
       Logger.log("LS2 = {0}", srcService.getLastSuccessfulSync());
}
```
```
LS1 = null
LS2 = Wed May 15 07:00:58 CDT 2024
```

By governing the lastSuccessfulSync, we are reducing the dataset that it returned to user for Synchronization and that in turn reduces all those extra calls to our internal services.