### PR TITLE
fallback to rhino if no default javascript is found (#280)

### DIFF
--- a/src/main/java/org/lsc/utils/ErrorMissingScriptEvaluator.java
+++ b/src/main/java/org/lsc/utils/ErrorMissingScriptEvaluator.java
@@ -1,0 +1,37 @@
+package org.lsc.utils;
+
+import org.lsc.Task;
+import org.lsc.exception.LscServiceException;
+
+import java.util.List;
+import java.util.Map;
+
+public class ErrorMissingScriptEvaluator
+implements ScriptableEvaluator {
+    @Override
+    public String evalToString(Task task, String expression, Map<String, Object> params) throws LscServiceException {
+        throw new LscServiceException("Missing Script evaluator");
+    }
+
+    @Override
+    public List<Object> evalToObjectList(Task task, String expression, Map<String, Object> params) throws LscServiceException {
+        throw new LscServiceException("Missing Script evaluator");
+    }
+
+    @Override
+    public List<byte[]> evalToByteArrayList(Task task, String expression, Map<String, Object> params) throws LscServiceException {
+        throw new LscServiceException("Missing Script evaluator");
+    }
+
+    @Override
+    public byte[] evalToByteArray(Task task, String expression, Map<String, Object> params) throws LscServiceException {
+        throw new LscServiceException("Missing Script evaluator");
+    }
+
+    @Override
+    public Boolean evalToBoolean(Task task, String expression, Map<String, Object> params) throws LscServiceException {
+        throw new LscServiceException("Missing Script evaluator");
+    }
+
+
+}

--- a/src/main/java/org/lsc/utils/ScriptingEvaluator.java
+++ b/src/main/java/org/lsc/utils/ScriptingEvaluator.java
@@ -40,6 +40,7 @@ public class ScriptingEvaluator {
 	}
 
 	private ScriptingEvaluator() {
+		defaultImplementation = new ErrorMissingScriptEvaluator();
 		instancesTypeCache = new HashMap<String, ScriptableEvaluator>();
 		List<ScriptEngineFactory> factories = mgr.getEngineFactories();
 		for (ScriptEngineFactory sef : factories) {
@@ -90,7 +91,12 @@ public class ScriptingEvaluator {
 			defaultImplementation = graaljsevaluator;
 		}
 		else {
-			defaultImplementation = instancesTypeCache.get("js");
+			for ( String name: new String[] {"js","rjs"} ) {
+				defaultImplementation = instancesTypeCache.get(name);
+				if ( defaultImplementation != null ) {
+					break;
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
- avoid NullPointerException
- always default to a non null defaut scripting implementation
  - default to ErrorMissingScriptEvalauator to fail a first unsupported scripting usage
- try to uee rhino if no js is