### PR TITLE
fallback to rhino if no default javascript is found .3 (lscproject#280)

### DIFF
--- a/src/main/java/org/lsc/utils/ScriptingEvaluator.java
+++ b/src/main/java/org/lsc/utils/ScriptingEvaluator.java
@@ -91,8 +91,8 @@ public class ScriptingEvaluator {
 			defaultImplementation = Optional.of(graaljsevaluator);
 		}
 		else {
-			defaultImplementation = Optional.ofNullable(instancesTypeCache.get("js"))
-					.or(() -> Optional.ofNullable(instancesTypeCache.get("rjs")));
+			defaultImplementation = Optional.ofNullable(Optional.ofNullable(instancesTypeCache.get("js"))
+					.orElse(instancesTypeCache.get("rjs")));
 		}
 	}
 


### PR DESCRIPTION
   - avoid NullPointerException even if rhino and js are missing