### PR TITLE
SAMPLE_HOME can contain spaces

### DIFF
--- a/sample/hsqldb/bin/lsc-sample
+++ b/sample/hsqldb/bin/lsc-sample
@@ -58,8 +58,8 @@ if [ ${SAMPLE_HOME:0:1} != "/" ] ; then
 fi
 
 # HSQLDB jar file
-[ -z "$HSQLDB_LIB" -a -e "$SAMPLE_HOME/../../lib/hsqldb*.jar" ] && HSQLDB_LIB=`ls "$SAMPLE_HOME/../../lib/hsqldb*.jar"`
-[ -z "$HSQLDB_LIB" -a -e "$SAMPLE_HOME/../lib/lsc/hsqldb*.jar" ] && HSQLDB_LIB=`ls "$SAMPLE_HOME/../lib/lsc/hsqldb*.jar"`
+[ -z "$HSQLDB_LIB" -a -e "$SAMPLE_HOME/../../lib/"hsqldb*.jar ] && HSQLDB_LIB=`ls "$SAMPLE_HOME/../../lib/"hsqldb*.jar`
+[ -z "$HSQLDB_LIB" -a -e "$SAMPLE_HOME/../lib/lsc/"hsqldb*.jar ] && HSQLDB_LIB=`ls "$SAMPLE_HOME/../lib/lsc/"hsqldb*.jar`
 [ -z "$HSQLDB_LIB" ] && echo "hsqldb driver (hsqldb*.jar) is missing" && exit 1
 # Temporary directory so that HSQLDB server could store files
 HSQLDB_DIR=/tmp/lsc/hsqldb

--- a/sample/hsqldb/bin/lsc-sample
+++ b/sample/hsqldb/bin/lsc-sample
@@ -58,8 +58,8 @@ if [ ${SAMPLE_HOME:0:1} != "/" ] ; then
 fi
 
 # HSQLDB jar file
-[ -z "$HSQLDB_LIB" -a -e $SAMPLE_HOME/../../lib/hsqldb*.jar ] && HSQLDB_LIB=`ls $SAMPLE_HOME/../../lib/hsqldb*.jar`
-[ -z "$HSQLDB_LIB" -a -e $SAMPLE_HOME/../lib/lsc/hsqldb*.jar ] && HSQLDB_LIB=`ls $SAMPLE_HOME/../lib/lsc/hsqldb*.jar`
+[ -z "$HSQLDB_LIB" -a -e "$SAMPLE_HOME/../../lib/hsqldb*.jar" ] && HSQLDB_LIB=`ls "$SAMPLE_HOME/../../lib/hsqldb*.jar"`
+[ -z "$HSQLDB_LIB" -a -e "$SAMPLE_HOME/../lib/lsc/hsqldb*.jar" ] && HSQLDB_LIB=`ls "$SAMPLE_HOME/../lib/lsc/hsqldb*.jar"`
 [ -z "$HSQLDB_LIB" ] && echo "hsqldb driver (hsqldb*.jar) is missing" && exit 1
 # Temporary directory so that HSQLDB server could store files
 HSQLDB_DIR=/tmp/lsc/hsqldb


### PR DESCRIPTION
Should fix issue from https://mail.ow2.org/wws/arc/lsc-users/2025-01/msg00008.html

>When I was trying to run 'bin/lsc-sample --import sample.csv' to import the CSV, I got this error:
```
s: Caretakers/lsc/lsc-2.1.6/sample/hsqldb/bin/../../../lib/hsqldb*.jar: No such file or directory
bin/lsc-sample: line 186: cd: /Users/jon/Documents/Commons: No such file or directory
Error: Unable to access jarfile
```
>The issue is that one of the folders had a space in the name, which caused the error. Once I replaced the space with an underscore, everything was fine.