### PR TITLE
fix error of izpack-maven-plugin for recent versions of openjdk 21 (#384)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
 			<plugin>
 				<groupId>org.codehaus.izpack</groupId>
 				<artifactId>izpack-maven-plugin</artifactId>
-				<version>5.2.3</version>
+				<version>5.2.4</version>
 
 				<!-- common configuration by all executions -->
 				<configuration>


### PR DESCRIPTION
Closes #384 