### PR TITLE
Fix for issue #430

### DIFF
--- a/src/main/java/org/lsc/service/SyncReplSourceService.java
+++ b/src/main/java/org/lsc/service/SyncReplSourceService.java
@@ -288,7 +288,7 @@ public class SyncReplSourceService extends SimpleJndiSrcService implements IAsyn
 		}
 		Response searchResponse = null;
 		try {
-			searchResponse = sf.get(1, TimeUnit.NANOSECONDS);
+			searchResponse = sf.get(); // Blocking call
 		} catch (InterruptedException e) {
 			LOGGER.warn("Interrupted search !");
 		}


### PR DESCRIPTION
A one line change to make the PersistentSearch` working without a sleep, making any modifications done in the origin server immediately injected into the destination server.

The sleep is still there if for some reason the `getNextId()` call returns null.