### PR TITLE
Patch CVE-2024-52046

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -756,6 +756,16 @@
 		</pluginRepository>
 	</pluginRepositories>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.mina</groupId>
+				<artifactId>mina-core</artifactId>
+				<version>2.2.5</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.forgerock.ce.opendj</groupId>


### PR DESCRIPTION
I use this project to build a docker image that is scanned by trivy, and it signal a critical CVE :

Severity | CVE | Package | Installed | Fixed | Target
-- | -- | -- | -- | -- | --
CRITICAL | CVE-2024-52046 | org.apache.mina:mina-core | 2.2.3 | 2.2.4, 2.1.10, 2.0.27 | Java

This PR solve this CVE by force use of mina-core 2.2.5