### PR TITLE
Add LdapRestDstService: write-through ldap-rest HTTP API

### DIFF
--- a/doc/ldap-rest-destination-service.md
+++ b/doc/ldap-rest-destination-service.md
@@ -1,0 +1,153 @@
+# LDAP REST destination service
+
+`LdapRestDstService` is an `IWritableService` implementation that
+sends modifications through an HTTP/JSON API instead of writing
+directly to an LDAP directory. It targets the
+[ldap-rest](https://github.com/linagora/ldap-rest) project, which
+exposes an LDAP-compatible REST API on top of an LDAP back-end and
+adds fine-grained ACLs, schema validation, audit logging and
+downstream webhooks.
+
+## When to use it
+
+Use `<ldapRestDestinationService>` when you want LSC to feed
+identity changes into a system that:
+
+- enforces ACLs on a per-resource / per-attribute basis;
+- runs business logic (provisioning, e-mail, badge…) on each
+  change via webhooks;
+- needs a strict audit trail tied to a service identity;
+- speaks JSON rather than LDAP for operational reasons.
+
+When the destination is a plain LDAP directory the existing
+`<ldapDestinationService>` is more efficient (single TCP
+connection, no JSON round-trip).
+
+## Configuration
+
+Drop a `<ldapRestDestinationService>` element in your task. Fields:
+
+| element             | required | default  | meaning                                                                  |
+|---------------------|----------|----------|--------------------------------------------------------------------------|
+| `<name>`            | yes      | —        | task-unique name, inherited from `serviceType`                           |
+| `<connection>`      | yes      | —        | inherited from `serviceType`; **ignored** at runtime by this service     |
+| `<baseUrl>`         | yes      | —        | scheme+host+port of the ldap-rest server, e.g. `https://ldap-rest.example.org` |
+| `<resourceType>`    | yes      | —        | one of `users`, `groups`, `organizations`, or any flat resource your ldap-rest server exposes |
+| `<apiPrefix>`       | no       | `/api`   | path prefix of the API (e.g. `/api/v2`); use `/` for no prefix           |
+| `<auth>`            | yes      | —        | authentication block, see below                                          |
+| `<timeoutMs>`       | no       | `10000`  | per-request timeout in milliseconds                                      |
+| `<retries>`         | no       | `3`      | number of retries on HTTP 5xx or I/O errors                              |
+| `<writeDatasetIds>` | no       | empty    | dataset ids this service is allowed to write (`<string>` children)       |
+
+The schema requires `<connection>` because every service inherits
+it from `serviceType`. `LdapRestDstService` does not actually use
+the bound connection; operators usually point it to a stub LDAP
+connection or any existing one to keep the schema valid.
+
+### Authentication
+
+Two auth strategies are supported. Pick one inside `<auth>`:
+
+```xml
+<auth>
+  <bearer>${LDAP_REST_TOKEN}</bearer>
+</auth>
+```
+
+or
+
+```xml
+<auth>
+  <hmacServiceId>lsc-prod</hmacServiceId>
+  <hmacSecret>${LDAP_REST_HMAC_SECRET}</hmacSecret>
+</auth>
+```
+
+The HMAC scheme uses HMAC-SHA256 over the canonical signing string
+`METHOD|PATH|TIMESTAMP|sha256(body)` and matches the verification
+performed by ldap-rest server-side. Variable expansion (`${VAR}`)
+follows the standard LSC configuration mechanism.
+
+## Example
+
+```xml
+<task>
+  <name>users-task</name>
+  <bean>org.lsc.beans.SimpleBean</bean>
+
+  <ldapSourceService>
+    <name>src-users</name>
+    <connection reference="src-ldap"/>
+    <baseDn>ou=users,dc=source,dc=example,dc=com</baseDn>
+    <pivotAttributes><string>uid</string></pivotAttributes>
+    <fetchedAttributes>
+      <string>uid</string><string>cn</string><string>sn</string>
+      <string>givenName</string><string>mail</string>
+    </fetchedAttributes>
+    <getAllFilter><![CDATA[(objectClass=inetOrgPerson)]]></getAllFilter>
+    <getOneFilter><![CDATA[(&(objectClass=inetOrgPerson)(uid={uid}))]]></getOneFilter>
+    <cleanFilter><![CDATA[(&(objectClass=inetOrgPerson)(uid={uid}))]]></cleanFilter>
+  </ldapSourceService>
+
+  <ldapRestDestinationService>
+    <name>dst-ldap-rest</name>
+    <connection reference="dst-stub"/>
+    <baseUrl>https://ldap-rest.example.org</baseUrl>
+    <resourceType>users</resourceType>
+    <auth>
+      <bearer>${LDAP_REST_TOKEN}</bearer>
+    </auth>
+    <timeoutMs>10000</timeoutMs>
+    <retries>3</retries>
+  </ldapRestDestinationService>
+
+  <propertiesBasedSyncOptions>
+    <mainIdentifier>"uid=" + srcBean.getDatasetFirstValueById("uid") + ",ou=users,dc=target,dc=example,dc=com"</mainIdentifier>
+    <defaultDelimiter>;</defaultDelimiter>
+    <defaultPolicy>FORCE</defaultPolicy>
+    <!-- … datasets … -->
+  </propertiesBasedSyncOptions>
+</task>
+```
+
+## Supported operations
+
+| LSC operation     | HTTP call                                                           |
+|-------------------|----------------------------------------------------------------------|
+| `CREATE_OBJECT`   | `POST /api/v1/ldap/{resourceType}` with full attribute object       |
+| `UPDATE_OBJECT`   | `PUT  /api/v1/ldap/{resourceType}/{id}` with `add`/`replace`/`delete` buckets |
+| `DELETE_OBJECT`   | `DELETE /api/v1/ldap/{resourceType}/{id}` (404 → idempotent success) |
+| `CHANGE_ID` (rename) | `POST /api/v1/ldap/groups/{cn}/rename` (groups, same parent)     |
+| `CHANGE_ID` (move)   | `POST /api/v1/ldap/{resourceType}/{id}/move`                     |
+
+For `groups`, mutations of the `member` attribute are routed to the
+dedicated `/members` and `/members/{member}` endpoints because
+ldap-rest forbids touching `member` through bulk PUT. Attribute-wide
+DELETE on `member` triggers a GET-then-delete-each reconciliation.
+
+## Identifier mapping
+
+| family         | URL identifier                                                |
+|----------------|---------------------------------------------------------------|
+| `users` (flat) | RDN value, e.g. `uid=alice,…` → `alice`                       |
+| `groups`       | `cn` value, e.g. `cn=admins,…` → `admins`                     |
+| `organizations`| URL-encoded full DN, e.g. `ou=sales,dc=ex,dc=org` → `ou%3Dsales%2Cdc%3Dex%2Cdc%3Dorg` |
+
+DN escapes (`\,`, `\\`, `\=`, `\xx` hex) are decoded via
+`javax.naming.ldap.LdapName` so the wire identifier is the
+*logical* value. The ldap-rest server re-escapes it on its side.
+
+## Limitations
+
+- **Binary attributes are not supported.** Values that fail strict
+  UTF-8 decoding raise `LscServiceException`. Plain UTF-8 byte
+  arrays (e.g. `userPassword` source) are accepted and forwarded as
+  strings.
+- **No bulk operations.** Each LSC modification produces one HTTP
+  call (with the exception of group member reconciliation, which
+  fans out one DELETE per current member).
+- **REPLACE on group `member` is best-effort.** It is implemented
+  as add-all-new without computing a delete-all-missing. Use
+  explicit ADD/DELETE for deterministic group sync.
+- **No source side.** The service only implements writes; LSC reads
+  source records from a separate `<*SourceService>`.

--- a/pom.xml
+++ b/pom.xml
@@ -1106,6 +1106,14 @@
       <scope>test</scope>
       <version>5.11.4</version>
     </dependency>
+
+    <!-- WireMock: HTTP server stubbing for the ldap-rest destination service tests -->
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>3.9.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/org/lsc/configuration/LscConfiguration.java
+++ b/src/main/java/org/lsc/configuration/LscConfiguration.java
@@ -65,6 +65,7 @@ import org.lsc.service.MultipleDstService;
 import org.lsc.service.SimpleJdbcDstService;
 import org.lsc.service.SimpleJdbcSrcService;
 import org.lsc.service.SyncReplSourceService;
+import org.lsc.service.ldaprest.LdapRestDstService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -337,6 +338,8 @@ public class LscConfiguration {
 			return t.getMultiDestinationService();
 		} else if (t.getPluginDestinationService() != null) {
 			return t.getPluginDestinationService();
+		} else if (t.getLdapRestDestinationService() != null) {
+			return t.getLdapRestDestinationService();
 		}
 		return null;
 	}
@@ -376,6 +379,8 @@ public class LscConfiguration {
 			t.setMultiDestinationService((MultiDestinationServiceType) s);
 		} else if (s instanceof LdapDestinationServiceType) {
 			t.setLdapDestinationService((LdapDestinationServiceType) s);
+		} else if (s instanceof LdapRestDestinationServiceType) {
+			t.setLdapRestDestinationService((LdapRestDestinationServiceType) s);
 		} else if (s instanceof PluginDestinationServiceType) {
 			t.setPluginDestinationService((PluginDestinationServiceType) s);
 		} else {
@@ -387,6 +392,8 @@ public class LscConfiguration {
 	public static Class<?> getServiceImplementation(ServiceType service) {
 		if (service instanceof LdapDestinationServiceType) {
 			return SimpleJndiDstService.class;
+		} else if (service instanceof LdapRestDestinationServiceType) {
+			return LdapRestDstService.class;
 		} else if (service instanceof AsyncLdapSourceServiceType) {
 			return SyncReplSourceService.class;
 		} else if (service instanceof LdapSourceServiceType) {

--- a/src/main/java/org/lsc/service/ldaprest/BearerAuth.java
+++ b/src/main/java/org/lsc/service/ldaprest/BearerAuth.java
@@ -1,0 +1,68 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import java.net.http.HttpRequest;
+import java.util.Objects;
+
+/**
+ * Static bearer-token authentication.
+ *
+ * <p>Adds {@code Authorization: Bearer &lt;token&gt;} to every
+ * outgoing request. The token is supposed to be opaque to the client
+ * and is provided by the ldap-rest deployment (typically through an
+ * environment variable expanded in {@code lsc.xml}).</p>
+ */
+public final class BearerAuth implements LdapRestAuth {
+
+    private final String token;
+
+    public BearerAuth(String token) {
+        this.token = Objects.requireNonNull(token, "token");
+        if (token.isEmpty()) {
+            throw new IllegalArgumentException("bearer token must not be empty");
+        }
+    }
+
+    @Override
+    public void apply(HttpRequest.Builder builder, String method, String path, byte[] body) {
+        builder.header("Authorization", "Bearer " + token);
+    }
+}

--- a/src/main/java/org/lsc/service/ldaprest/HmacAuth.java
+++ b/src/main/java/org/lsc/service/ldaprest/HmacAuth.java
@@ -1,0 +1,159 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+import java.util.Objects;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * HMAC-SHA256 request signing matching the ldap-rest server-side
+ * verification. The signing string is:
+ *
+ * <pre>
+ *   signingString = METHOD + "|" + PATH + "|" + timestamp + "|" + bodyHash
+ *   bodyHash      = sha256_hex(body)            (POST/PUT/PATCH)
+ *                 = ""                          (GET/DELETE/HEAD)
+ *   timestamp     = currentTimeMillis()         (milliseconds)
+ *   signature     = hmac_sha256_hex(secret, signingString)
+ *   header        = "HMAC-SHA256 &lt;serviceId&gt;:&lt;timestamp&gt;:&lt;signature&gt;"
+ * </pre>
+ *
+ * <p>The body bytes used for {@code bodyHash} <strong>must</strong>
+ * be the exact bytes sent on the wire (UTF-8 encoded JSON in our
+ * case). The HTTP client takes care of feeding the same byte array
+ * to both the signature and the request body.</p>
+ */
+public final class HmacAuth implements LdapRestAuth {
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    private final String serviceId;
+    private final String secret;
+    private final TimestampSource clock;
+
+    public HmacAuth(String serviceId, String secret) {
+        this(serviceId, secret, System::currentTimeMillis);
+    }
+
+    /**
+     * Test-only constructor injecting a fixed timestamp source so
+     * signatures are reproducible.
+     */
+    public HmacAuth(String serviceId, String secret, TimestampSource clock) {
+        this.serviceId = Objects.requireNonNull(serviceId, "serviceId");
+        this.secret = Objects.requireNonNull(secret, "secret");
+        this.clock = Objects.requireNonNull(clock, "clock");
+        if (serviceId.isEmpty() || secret.isEmpty()) {
+            throw new IllegalArgumentException("serviceId and secret must not be empty");
+        }
+    }
+
+    @Override
+    public void apply(HttpRequest.Builder builder, String method, String path, byte[] body) {
+        long ts = clock.now();
+        String upper = method.toUpperCase(Locale.ROOT);
+        boolean hasBody = upper.equals("POST") || upper.equals("PUT") || upper.equals("PATCH");
+        String bodyHash = hasBody ? sha256Hex(body == null ? new byte[0] : body) : "";
+        String signingString = upper + "|" + path + "|" + ts + "|" + bodyHash;
+        String signature = hmacSha256Hex(secret, signingString);
+        String headerValue = "HMAC-SHA256 " + serviceId + ":" + ts + ":" + signature;
+        builder.header("Authorization", headerValue);
+    }
+
+    /**
+     * Compute the signature for given inputs without sending a
+     * request. Exposed so callers (and tests) can pre-compute
+     * expected values.
+     */
+    public static String computeSignature(String secret,
+                                          String method,
+                                          String path,
+                                          long timestamp,
+                                          byte[] body) {
+        String upper = method.toUpperCase(Locale.ROOT);
+        boolean hasBody = upper.equals("POST") || upper.equals("PUT") || upper.equals("PATCH");
+        String bodyHash = hasBody ? sha256Hex(body == null ? new byte[0] : body) : "";
+        String signingString = upper + "|" + path + "|" + timestamp + "|" + bodyHash;
+        return hmacSha256Hex(secret, signingString);
+    }
+
+    static String sha256Hex(byte[] data) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return toHex(md.digest(data));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    static String hmacSha256Hex(String secret, String signingString) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] sig = mac.doFinal(signingString.getBytes(StandardCharsets.UTF_8));
+            return toHex(sig);
+        } catch (Exception e) {
+            throw new IllegalStateException("HmacSHA256 unavailable", e);
+        }
+    }
+
+    static String toHex(byte[] data) {
+        char[] out = new char[data.length * 2];
+        for (int i = 0; i < data.length; i++) {
+            int v = data[i] & 0xff;
+            out[i * 2] = HEX[v >>> 4];
+            out[i * 2 + 1] = HEX[v & 0x0f];
+        }
+        return new String(out);
+    }
+
+    /** Test seam for clock injection. */
+    @FunctionalInterface
+    public interface TimestampSource {
+        long now();
+    }
+}

--- a/src/main/java/org/lsc/service/ldaprest/LdapRestAuth.java
+++ b/src/main/java/org/lsc/service/ldaprest/LdapRestAuth.java
@@ -1,0 +1,69 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import java.net.http.HttpRequest;
+
+/**
+ * Pluggable authentication strategy that adds the relevant
+ * Authorization header on an outgoing HTTP request to ldap-rest.
+ *
+ * <p>The strategy receives the parsed components of the request
+ * ({@code method}, {@code path}, {@code body}) so that signed schemes
+ * (HMAC) can compute their signature. Stateless schemes (Bearer)
+ * simply add a static header.</p>
+ *
+ * <p>Implementations <strong>must</strong> be safe for concurrent use
+ * across multiple HTTP clients/threads.</p>
+ */
+public interface LdapRestAuth {
+
+    /**
+     * Apply this auth strategy to {@code builder}, signing the
+     * outgoing request based on its method, path and body.
+     *
+     * @param builder the {@link HttpRequest.Builder} being built
+     * @param method  the HTTP method, upper case (e.g. {@code POST})
+     * @param path    the request path, e.g. {@code /api/v1/ldap/users}
+     * @param body    the body bytes that will be sent, or empty for
+     *                methods without a body (GET, DELETE, HEAD)
+     */
+    void apply(HttpRequest.Builder builder, String method, String path, byte[] body);
+}

--- a/src/main/java/org/lsc/service/ldaprest/LdapRestClient.java
+++ b/src/main/java/org/lsc/service/ldaprest/LdapRestClient.java
@@ -1,0 +1,230 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+
+import org.lsc.exception.LscServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Thin wrapper around {@link HttpClient} for talking to ldap-rest.
+ *
+ * <p>Responsibilities:</p>
+ * <ul>
+ *     <li>Apply the configured {@link LdapRestAuth} on every request,
+ *         feeding it the same body bytes that go on the wire so that
+ *         HMAC signatures match.</li>
+ *     <li>Build the absolute URL from a base URL and path.</li>
+ *     <li>Retry transient errors (5xx, IOException) with capped
+ *         exponential backoff.</li>
+ *     <li>Translate non-2xx responses into {@link LscServiceException}.</li>
+ * </ul>
+ *
+ * <p>Idempotent special cases (404 on DELETE) are handled by the
+ * caller, not here, so the client stays generic.</p>
+ */
+public class LdapRestClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LdapRestClient.class);
+
+    private final String baseUrl;
+    private final LdapRestAuth auth;
+    private final long timeoutMs;
+    private final int retries;
+    private final HttpClient http;
+    private final Sleeper sleeper;
+
+    public LdapRestClient(String baseUrl, LdapRestAuth auth, long timeoutMs, int retries) {
+        this(baseUrl, auth, timeoutMs, retries,
+                HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofMillis(Math.max(1000, timeoutMs)))
+                        .build(),
+                ms -> {
+                    try {
+                        Thread.sleep(ms);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+    }
+
+    /** Test-friendly constructor allowing HttpClient and Sleeper injection. */
+    public LdapRestClient(String baseUrl, LdapRestAuth auth, long timeoutMs, int retries,
+                          HttpClient http, Sleeper sleeper) {
+        this.baseUrl = stripTrailingSlash(Objects.requireNonNull(baseUrl, "baseUrl"));
+        this.auth = Objects.requireNonNull(auth, "auth");
+        if (timeoutMs <= 0) {
+            throw new IllegalArgumentException("timeoutMs must be positive");
+        }
+        if (retries < 0) {
+            throw new IllegalArgumentException("retries must be >= 0");
+        }
+        this.timeoutMs = timeoutMs;
+        this.retries = retries;
+        this.http = Objects.requireNonNull(http, "http");
+        this.sleeper = Objects.requireNonNull(sleeper, "sleeper");
+    }
+
+    public HttpResponse<String> get(String path) throws LscServiceException {
+        return send("GET", path, null);
+    }
+
+    public HttpResponse<String> delete(String path) throws LscServiceException {
+        return send("DELETE", path, null);
+    }
+
+    public HttpResponse<String> post(String path, String jsonBody) throws LscServiceException {
+        return send("POST", path, jsonBody == null ? new byte[0] : jsonBody.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public HttpResponse<String> put(String path, String jsonBody) throws LscServiceException {
+        return send("PUT", path, jsonBody == null ? new byte[0] : jsonBody.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Low-level send with retry and auth. {@code body} is the exact
+     * payload bytes sent to the server; the same array is used to
+     * compute the HMAC signature.
+     */
+    public HttpResponse<String> send(String method, String path, byte[] body) throws LscServiceException {
+        Objects.requireNonNull(method, "method");
+        Objects.requireNonNull(path, "path");
+        URI uri = URI.create(baseUrl + path);
+        IOException lastIo = null;
+        HttpResponse<String> last5xx = null;
+        for (int attempt = 0; attempt <= retries; attempt++) {
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .timeout(Duration.ofMillis(timeoutMs));
+            byte[] bodyBytes = body == null ? new byte[0] : body;
+            switch (method) {
+                case "GET":
+                    builder.GET();
+                    break;
+                case "DELETE":
+                    builder.DELETE();
+                    break;
+                case "POST":
+                    builder.header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofByteArray(bodyBytes));
+                    break;
+                case "PUT":
+                    builder.header("Content-Type", "application/json")
+                            .PUT(HttpRequest.BodyPublishers.ofByteArray(bodyBytes));
+                    break;
+                default:
+                    throw new LscServiceException("Unsupported HTTP method: " + method);
+            }
+            builder.header("Accept", "application/json");
+            // Auth must run after Content-Type so headers are visible
+            // but before send so the timestamp is fresh per attempt.
+            auth.apply(builder, method, path, bodyBytes);
+            HttpRequest req = builder.build();
+            try {
+                HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                int code = resp.statusCode();
+                if (code >= 200 && code < 300) {
+                    return resp;
+                }
+                if (code >= 500 && attempt < retries) {
+                    last5xx = resp;
+                    long wait = backoffMillis(attempt);
+                    LOG.warn("ldap-rest {} {} returned {}, retrying in {}ms (attempt {}/{})",
+                            method, path, code, wait, attempt + 1, retries);
+                    sleeper.sleep(wait);
+                    continue;
+                }
+                // Non-retryable error
+                throw new LscServiceException("ldap-rest " + method + " " + path
+                        + " failed with HTTP " + code + ": " + truncate(resp.body()));
+            } catch (IOException ioe) {
+                lastIo = ioe;
+                if (attempt < retries) {
+                    long wait = backoffMillis(attempt);
+                    LOG.warn("ldap-rest {} {} I/O error: {}, retrying in {}ms (attempt {}/{})",
+                            method, path, ioe.getMessage(), wait, attempt + 1, retries);
+                    sleeper.sleep(wait);
+                    continue;
+                }
+                throw new LscServiceException("ldap-rest " + method + " " + path + " failed: " + ioe.getMessage(), ioe);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new LscServiceException("ldap-rest " + method + " " + path + " interrupted", ie);
+            }
+        }
+        if (last5xx != null) {
+            throw new LscServiceException("ldap-rest " + method + " " + path
+                    + " failed after " + retries + " retries with HTTP "
+                    + last5xx.statusCode() + ": " + truncate(last5xx.body()));
+        }
+        throw new LscServiceException("ldap-rest " + method + " " + path
+                + " failed after " + retries + " retries", lastIo);
+    }
+
+    private static long backoffMillis(int attempt) {
+        // 100ms, 200ms, 400ms, 800ms, capped at 5s
+        long base = 100L * (1L << Math.min(attempt, 6));
+        return Math.min(base, 5000L);
+    }
+
+    private static String truncate(String s) {
+        if (s == null) return "";
+        return s.length() > 500 ? s.substring(0, 500) + "..." : s;
+    }
+
+    private static String stripTrailingSlash(String s) {
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    /** Test seam for backoff sleep. */
+    @FunctionalInterface
+    public interface Sleeper {
+        void sleep(long ms);
+    }
+}

--- a/src/main/java/org/lsc/service/ldaprest/LdapRestDstService.java
+++ b/src/main/java/org/lsc/service/ldaprest/LdapRestDstService.java
@@ -1,0 +1,456 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.lsc.LscDatasetModification;
+import org.lsc.LscDatasets;
+import org.lsc.LscModifications;
+import org.lsc.beans.IBean;
+import org.lsc.configuration.ConnectionType;
+import org.lsc.configuration.LdapRestAuthType;
+import org.lsc.configuration.LdapRestDestinationServiceType;
+import org.lsc.configuration.TaskType;
+import org.lsc.configuration.ValuesType;
+import org.lsc.exception.LscServiceException;
+import org.lsc.service.IWritableService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * LSC {@link IWritableService} that writes through the ldap-rest
+ * HTTP API.
+ *
+ * <p>Configuration is read from the
+ * {@code <ldapRestDestinationService>} element in {@code lsc.xml};
+ * LSC hands us the parsed {@link TaskType} and we use the typed
+ * JAXB getters of {@link LdapRestDestinationServiceType}. Recognised
+ * elements:</p>
+ *
+ * <ul>
+ *     <li>{@code <baseUrl>} — required, e.g. {@code https://ldap-rest.example.org}</li>
+ *     <li>{@code <resourceType>} — required, one of {@code users},
+ *         {@code groups}, {@code organizations}, …</li>
+ *     <li>{@code <auth>} block containing either {@code <bearer>} or
+ *         {@code <hmacServiceId>}+{@code <hmacSecret>}</li>
+ *     <li>{@code <timeoutMs>} — optional, default 10000ms</li>
+ *     <li>{@code <retries>} — optional, default 3</li>
+ *     <li>{@code <apiPrefix>} — optional, default {@code /api}</li>
+ *     <li>{@code <writeDatasetIds>} — optional list of dataset ids
+ *         this service is allowed to write</li>
+ * </ul>
+ *
+ * <p>This service is purely <strong>destination</strong>: the read
+ * methods ({@code getBean}, {@code getListPivots}) are stubbed
+ * because LSC pulls source records from a separate source service
+ * and only feeds us {@link LscModifications}. They return empty
+ * structures so the framework does not crash if it ever calls
+ * them.</p>
+ *
+ * <p>The {@code <connection>} reference inherited from
+ * {@code serviceType} is required by the schema but ignored at
+ * runtime: ldap-rest auth is configured inline via {@code <auth>}.
+ * Operators usually point it to a stub LDAP connection just to keep
+ * the schema happy.</p>
+ */
+public class LdapRestDstService implements IWritableService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LdapRestDstService.class);
+
+    private final LdapRestClient client;
+    private final ResourceMapper mapper;
+    private final ModificationTranslator translator;
+    private final List<String> writeDatasetIds;
+
+    /**
+     * LSC constructor signature. Called once per task before sync.
+     */
+    public LdapRestDstService(TaskType task) throws LscServiceException {
+        Config cfg = parseConfig(task);
+        this.mapper = new ResourceMapper(cfg.resourceType, cfg.apiPrefix);
+        this.translator = new ModificationTranslator(this.mapper);
+        this.client = new LdapRestClient(cfg.baseUrl, cfg.auth, cfg.timeoutMs, cfg.retries);
+        this.writeDatasetIds = cfg.writeDatasetIds;
+        LOG.info("ldap-rest destination service initialised: baseUrl={}, resourceType={}, "
+                        + "auth={}, timeoutMs={}, retries={}",
+                cfg.baseUrl, cfg.resourceType, cfg.auth.getClass().getSimpleName(),
+                cfg.timeoutMs, cfg.retries);
+    }
+
+    /** Test-only constructor injecting an already-built client. */
+    LdapRestDstService(LdapRestClient client, ResourceMapper mapper) {
+        this.client = client;
+        this.mapper = mapper;
+        this.translator = new ModificationTranslator(mapper);
+        this.writeDatasetIds = Collections.emptyList();
+    }
+
+    @Override
+    public boolean apply(LscModifications lm) throws LscServiceException {
+        if (lm == null || lm.getOperation() == null) {
+            throw new LscServiceException("LscModifications has no operation");
+        }
+        switch (lm.getOperation()) {
+            case CREATE_OBJECT:
+                return doCreate(lm);
+            case UPDATE_OBJECT:
+                return doUpdate(lm);
+            case DELETE_OBJECT:
+                return doDelete(lm);
+            case CHANGE_ID:
+                return doModrdn(lm);
+            default:
+                throw new LscServiceException("Unsupported LSC operation: " + lm.getOperation());
+        }
+    }
+
+    private boolean doCreate(LscModifications lm) throws LscServiceException {
+        String body = translator.buildCreateBody(lm);
+        String path = mapper.collectionPath();
+        HttpResponse<String> resp = client.post(path, body);
+        LOG.debug("CREATE {} -> {}", path, resp.statusCode());
+        return true;
+    }
+
+    private boolean doUpdate(LscModifications lm) throws LscServiceException {
+        // For UPDATE on group, member-mutating attributes must use
+        // the dedicated /members endpoints; ldap-rest itself enforces
+        // this. We split the payload accordingly.
+        if (mapper.getFamily() == ResourceMapper.Family.GROUPS) {
+            return doGroupUpdate(lm);
+        }
+        String body = translator.buildUpdateBody(lm);
+        String path = mapper.itemPath(lm.getMainIdentifier());
+        HttpResponse<String> resp = client.put(path, body);
+        LOG.debug("UPDATE {} -> {}", path, resp.statusCode());
+        return true;
+    }
+
+    /**
+     * Group updates are special: ldap-rest forbids touching the
+     * {@code member} attribute through PUT and exposes dedicated
+     * member endpoints. We extract member ADD/DELETE operations
+     * first, fire dedicated calls for each, then fall back to PUT
+     * for non-member attribute changes.
+     */
+    private boolean doGroupUpdate(LscModifications lm) throws LscServiceException {
+        List<LscDatasetModification> rest = new ArrayList<>();
+        List<Object> addedMembers = new ArrayList<>();
+        List<Object> removedMembers = new ArrayList<>();
+        boolean replaceMembers = false;
+        List<Object> replacedMembers = Collections.emptyList();
+
+        for (LscDatasetModification mod : safeList(lm.getLscAttributeModifications())) {
+            if ("member".equalsIgnoreCase(mod.getAttributeName())) {
+                List<Object> values = mod.getValues() == null ? Collections.emptyList() : mod.getValues();
+                switch (mod.getOperation()) {
+                    case ADD_VALUES:
+                        addedMembers.addAll(values);
+                        break;
+                    case DELETE_VALUES:
+                        if (values.isEmpty()) {
+                            // attribute-wide delete on `member` — best-effort
+                            // reconciliation: GET the group, list its current
+                            // members, and queue them all for deletion. If the
+                            // GET fails we surface a clear error rather than
+                            // silently no-op.
+                            List<Object> current = fetchCurrentMembers(lm.getMainIdentifier());
+                            LOG.info("attribute-wide DELETE on group 'member' for {}: removing {} current member(s) via reconciliation",
+                                    lm.getMainIdentifier(), current.size());
+                            removedMembers.addAll(current);
+                        } else {
+                            removedMembers.addAll(values);
+                        }
+                        break;
+                    case REPLACE_VALUES:
+                        replaceMembers = true;
+                        replacedMembers = new ArrayList<>(values);
+                        break;
+                    default:
+                        break;
+                }
+            } else {
+                rest.add(mod);
+            }
+        }
+
+        // Apply replace-members as a (delete-all + add-all) sequence
+        // because ldap-rest has no "replace members" endpoint.
+        if (replaceMembers) {
+            // We don't currently fetch the existing list (this service
+            // is destination-only) so we approximate by removing the
+            // explicit additions/removals first, then adding the new
+            // set. Operators wanting a full reconciliation should use
+            // ADD_VALUES/DELETE_VALUES explicitly in their sync map.
+            LOG.warn("REPLACE on group 'member' is best-effort: missing members will not be removed."
+                    + " Use ADD_VALUES/DELETE_VALUES for deterministic group sync.");
+            addedMembers.addAll(replacedMembers);
+        }
+
+        for (Object m : addedMembers) {
+            String memberDn = String.valueOf(m);
+            String path = mapper.membersPath(lm.getMainIdentifier());
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("member", memberDn);
+            client.post(path, ModificationTranslator.writeJson(body));
+        }
+        for (Object m : removedMembers) {
+            String memberDn = String.valueOf(m);
+            String path = mapper.memberItemPath(lm.getMainIdentifier(), memberDn);
+            client.delete(path);
+        }
+
+        if (!rest.isEmpty()) {
+            LscModifications stripped = new LscModifications(lm.getOperation(), lm.getTaskName());
+            stripped.setMainIdentifer(lm.getMainIdentifier());
+            stripped.setNewMainIdentifier(lm.getNewMainIdentifier());
+            stripped.setLscAttributeModifications(rest);
+            String body = translator.buildUpdateBody(stripped);
+            // Avoid an empty PUT (no buckets) when only members changed.
+            if (!"{}".equals(body)) {
+                String path = mapper.itemPath(lm.getMainIdentifier());
+                client.put(path, body);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * GET the group at {@code groupDn}, parse its JSON, and return the
+     * current {@code member} list. Used to reconcile attribute-wide
+     * DELETE on {@code member} when LSC emits no explicit value list.
+     */
+    private List<Object> fetchCurrentMembers(String groupDn) throws LscServiceException {
+        String path = mapper.itemPath(groupDn);
+        HttpResponse<String> resp = client.get(path);
+        return ModificationTranslator.readMembers(resp.body());
+    }
+
+    private boolean doDelete(LscModifications lm) throws LscServiceException {
+        String path = mapper.itemPath(lm.getMainIdentifier());
+        try {
+            HttpResponse<String> resp = client.delete(path);
+            LOG.debug("DELETE {} -> {}", path, resp.statusCode());
+            return true;
+        } catch (LscServiceException e) {
+            // 404 on DELETE = soft idempotence
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("HTTP 404")) {
+                LOG.warn("DELETE {} returned 404 — already absent, treating as success", path);
+                return true;
+            }
+            throw e;
+        }
+    }
+
+    private boolean doModrdn(LscModifications lm) throws LscServiceException {
+        ModificationTranslator.ModrdnPayload payload = translator.buildModrdnPayload(lm);
+        String path;
+        if (payload.kind == ModificationTranslator.ModrdnKind.RENAME) {
+            path = mapper.renamePath(lm.getMainIdentifier());
+        } else {
+            path = mapper.movePath(lm.getMainIdentifier());
+        }
+        HttpResponse<String> resp = client.post(path, payload.body);
+        LOG.debug("MODRDN {} {} -> {}", payload.kind, path, resp.statusCode());
+        return true;
+    }
+
+    @Override
+    public List<String> getWriteDatasetIds() {
+        return writeDatasetIds == null ? Collections.emptyList() : writeDatasetIds;
+    }
+
+    /**
+     * Read-side: this service is destination-only. LSC requires the
+     * methods to exist (because {@link IWritableService} extends
+     * {@code IService}) but we are never the source. Returning empty
+     * structures keeps LSC happy in defensive code paths.
+     */
+    @Override
+    public IBean getBean(String pivotName, LscDatasets pivotAttributes, boolean fromSameService)
+            throws LscServiceException {
+        LOG.debug("getBean({}) called on destination-only service — returning null", pivotName);
+        return null;
+    }
+
+    @Override
+    public Map<String, LscDatasets> getListPivots() throws LscServiceException {
+        LOG.debug("getListPivots() called on destination-only service — returning empty map");
+        return new HashMap<>();
+    }
+
+    @Override
+    public Collection<Class<? extends ConnectionType>> getSupportedConnectionType() {
+        // We do not bind to a typed LSC connection (no LDAP, no JDBC);
+        // ldap-rest auth is configured inline. Return empty so LSC
+        // doesn't try to inject one.
+        return Collections.emptyList();
+    }
+
+    // -------------------------------------------------------------------
+    // configuration parsing
+    // -------------------------------------------------------------------
+
+    static class Config {
+        String baseUrl;
+        String resourceType;
+        String apiPrefix = "/api";
+        long timeoutMs = 10_000L;
+        int retries = 3;
+        LdapRestAuth auth;
+        List<String> writeDatasetIds = new ArrayList<>();
+    }
+
+    static Config parseConfig(TaskType task) throws LscServiceException {
+        if (task == null) {
+            throw new LscServiceException("ldap-rest destination service: TaskType is null");
+        }
+        LdapRestDestinationServiceType svc = task.getLdapRestDestinationService();
+        if (svc == null) {
+            throw new LscServiceException(
+                    "ldap-rest destination service: <ldapRestDestinationService> not configured");
+        }
+        return parseConfig(svc);
+    }
+
+    /**
+     * Parse the typed JAXB configuration directly. Exposed for unit
+     * tests so they can build a {@link LdapRestDestinationServiceType}
+     * on the fly without going through a full {@link TaskType}.
+     */
+    static Config parseConfig(LdapRestDestinationServiceType svc) throws LscServiceException {
+        if (svc == null) {
+            throw new LscServiceException("ldap-rest destination service: configuration is null");
+        }
+        Config cfg = new Config();
+        cfg.baseUrl = trimToNull(svc.getBaseUrl());
+        cfg.resourceType = trimToNull(svc.getResourceType());
+        String prefix = trimToNull(svc.getApiPrefix());
+        if (prefix != null) {
+            cfg.apiPrefix = normaliseApiPrefix(prefix);
+        }
+        Long timeout = svc.getTimeoutMs();
+        if (timeout != null) {
+            if (timeout <= 0) {
+                throw new LscServiceException("<timeoutMs> must be > 0, got: " + timeout);
+            }
+            cfg.timeoutMs = timeout;
+        }
+        Integer retries = svc.getRetries();
+        if (retries != null) {
+            if (retries < 0) {
+                throw new LscServiceException("<retries> must be >= 0, got: " + retries);
+            }
+            cfg.retries = retries;
+        }
+        ValuesType ids = svc.getWriteDatasetIds();
+        if (ids != null && ids.getString() != null) {
+            for (String s : ids.getString()) {
+                if (s == null) continue;
+                String t = s.trim();
+                if (!t.isEmpty()) cfg.writeDatasetIds.add(t);
+            }
+        }
+        if (cfg.baseUrl == null) {
+            throw new LscServiceException("ldap-rest destination service: <baseUrl> is required");
+        }
+        if (cfg.resourceType == null) {
+            throw new LscServiceException("ldap-rest destination service: <resourceType> is required");
+        }
+        cfg.auth = parseAuth(svc.getAuth());
+        return cfg;
+    }
+
+    static LdapRestAuth parseAuth(LdapRestAuthType authElement) throws LscServiceException {
+        if (authElement == null) {
+            throw new LscServiceException(
+                    "ldap-rest destination service: <auth> block missing — provide <bearer> or "
+                            + "<hmacServiceId>+<hmacSecret>");
+        }
+        String bearer = trimToNull(authElement.getBearer());
+        String svcId = trimToNull(authElement.getHmacServiceId());
+        String secret = trimToNull(authElement.getHmacSecret());
+        if (bearer != null) {
+            return new BearerAuth(bearer);
+        }
+        if (svcId != null && secret != null) {
+            return new HmacAuth(svcId, secret);
+        }
+        throw new LscServiceException(
+                "ldap-rest destination service: <auth> needs either <bearer> or both "
+                        + "<hmacServiceId> and <hmacSecret>");
+    }
+
+    /**
+     * Normalise {@code <apiPrefix>}: ensure leading {@code /}, strip
+     * trailing {@code /}. So {@code "api"}, {@code "/api"}, {@code "/api/"}
+     * all become {@code "/api"}. Also accepts the empty prefix {@code "/"}.
+     */
+    static String normaliseApiPrefix(String raw) {
+        String s = raw.trim();
+        if (s.isEmpty() || "/".equals(s)) return "";
+        if (!s.startsWith("/")) s = "/" + s;
+        while (s.length() > 1 && s.endsWith("/")) s = s.substring(0, s.length() - 1);
+        return s;
+    }
+
+    private static String trimToNull(String s) {
+        if (s == null) return null;
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
+    }
+
+    private static <T> List<T> safeList(List<T> l) {
+        return l == null ? Collections.emptyList() : l;
+    }
+
+    /** Test seam to expose internals to the integration test. */
+    LdapRestClient client() { return client; }
+    ResourceMapper mapper() { return mapper; }
+}

--- a/src/main/java/org/lsc/service/ldaprest/ModificationTranslator.java
+++ b/src/main/java/org/lsc/service/ldaprest/ModificationTranslator.java
@@ -1,0 +1,329 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.lsc.LscDatasetModification;
+import org.lsc.LscDatasetModification.LscDatasetModificationType;
+import org.lsc.LscModifications;
+import org.lsc.exception.LscServiceException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * Convert {@link LscModifications} objects into JSON payloads
+ * understood by ldap-rest.
+ *
+ * <p>The class uses a single {@link ObjectMapper} configured for
+ * compact, deterministic output (no pretty-printing, insertion-order
+ * preserving maps). This is critical because the same bytes that go
+ * on the wire are also used to compute the HMAC signature; any
+ * formatting change would break the server-side signature
+ * verification.</p>
+ *
+ * <p>Mapping cheat-sheet:</p>
+ * <ul>
+ *     <li><b>CREATE flat/org</b>: a single JSON object whose keys are
+ *         the attribute names and values are either a scalar
+ *         (single-valued) or an array (multi-valued).</li>
+ *     <li><b>CREATE group</b>: same shape, ldap-rest expects {@code cn},
+ *         optional {@code description} and {@code member}.</li>
+ *     <li><b>UPDATE</b>: an object with {@code add}, {@code replace}
+ *         and/or {@code delete} buckets, mirroring LSC's
+ *         {@link LscDatasetModificationType}.</li>
+ *     <li><b>MODRDN flat/org</b>: {@code { "targetOrgDn": "..." }}.</li>
+ *     <li><b>MODRDN group</b>: {@code { "newCn": "..." }}.</li>
+ * </ul>
+ */
+public class ModificationTranslator {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .disable(SerializationFeature.INDENT_OUTPUT)
+            // serializing Maps preserves insertion order by default;
+            // we just need to ensure no other reordering kicks in.
+            .disable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
+
+    private final ResourceMapper resourceMapper;
+
+    public ModificationTranslator(ResourceMapper resourceMapper) {
+        this.resourceMapper = resourceMapper;
+    }
+
+    /**
+     * Build the body for a CREATE call (POST /collection).
+     */
+    public String buildCreateBody(LscModifications lm) throws LscServiceException {
+        Map<String, Object> body = new LinkedHashMap<>();
+        for (LscDatasetModification mod : safeList(lm.getLscAttributeModifications())) {
+            if (mod.getOperation() == LscDatasetModificationType.DELETE_VALUES) {
+                // CREATE shouldn't carry deletions; ignore defensively.
+                continue;
+            }
+            Object val = collapse(mod.getAttributeName(), mod.getValues());
+            if (val != null) {
+                body.put(mod.getAttributeName(), val);
+            }
+        }
+        return writeJson(body);
+    }
+
+    /**
+     * Build the body for an UPDATE call (PUT /collection/id).
+     *
+     * <p>Output shape:
+     * <pre>
+     *   {
+     *     "replace": { attr: [v1, v2] },
+     *     "add":     { attr: [v1] },
+     *     "delete":  { attr: [v1] }   // value-targeted
+     *               | ["attr1", "attr2"]   // attribute-wide
+     *   }
+     * </pre>
+     * If both forms of {@code delete} appear, they are merged into
+     * the value-targeted shape with {@code []} marking attribute-wide
+     * deletes (an empty list is the convention used by ldap-rest's
+     * server-side parser).</p>
+     */
+    public String buildUpdateBody(LscModifications lm) throws LscServiceException {
+        Map<String, List<Object>> replace = new LinkedHashMap<>();
+        Map<String, List<Object>> add = new LinkedHashMap<>();
+        Map<String, List<Object>> deleteValues = new LinkedHashMap<>();
+        List<String> deleteAttrs = new ArrayList<>();
+
+        for (LscDatasetModification mod : safeList(lm.getLscAttributeModifications())) {
+            String name = mod.getAttributeName();
+            List<Object> vals = sanitizeValues(name, mod.getValues());
+            switch (mod.getOperation()) {
+                case REPLACE_VALUES:
+                    replace.put(name, vals);
+                    break;
+                case ADD_VALUES:
+                    add.put(name, vals);
+                    break;
+                case DELETE_VALUES:
+                    if (vals.isEmpty()) {
+                        deleteAttrs.add(name);
+                    } else {
+                        deleteValues.put(name, vals);
+                    }
+                    break;
+                default:
+                    // UNKNOWN — skip
+                    break;
+            }
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        if (!replace.isEmpty()) body.put("replace", replace);
+        if (!add.isEmpty()) body.put("add", add);
+        if (!deleteValues.isEmpty() || !deleteAttrs.isEmpty()) {
+            if (deleteValues.isEmpty()) {
+                body.put("delete", deleteAttrs);
+            } else {
+                // merge: attribute-wide deletes become attr -> [] entries
+                for (String attr : deleteAttrs) {
+                    deleteValues.putIfAbsent(attr, Collections.emptyList());
+                }
+                body.put("delete", deleteValues);
+            }
+        }
+        return writeJson(body);
+    }
+
+    /**
+     * Build the body for a MODRDN call. For flat/org resources the
+     * payload is {@code { "targetOrgDn": newParent }}. For groups
+     * with only an RDN change it is {@code { "newCn": newCn }}.
+     *
+     * <p>The translator picks the form based on the resource family
+     * <em>and</em> on whether the new parent DN differs from the
+     * current parent DN. If the parent DN is unchanged we treat it
+     * as a pure rename (group only); if the parent changed we issue
+     * a move.</p>
+     *
+     * @return a result object holding both the JSON body and the
+     *         endpoint hint (rename vs move) so the caller can pick
+     *         the right path.
+     */
+    public ModrdnPayload buildModrdnPayload(LscModifications lm) throws LscServiceException {
+        String oldDn = lm.getMainIdentifier();
+        String newDn = lm.getNewMainIdentifier();
+        if (newDn == null || newDn.isEmpty()) {
+            throw new LscServiceException("MODRDN without newMainIdentifier on " + oldDn);
+        }
+        String oldParent = ResourceMapper.parentDn(oldDn == null ? "" : oldDn);
+        String newParent = ResourceMapper.parentDn(newDn);
+        boolean parentChanged = !oldParent.equalsIgnoreCase(newParent);
+
+        if (resourceMapper.getFamily() == ResourceMapper.Family.GROUPS && !parentChanged) {
+            String newCn = ResourceMapper.rdnValue(newDn);
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("newCn", newCn);
+            return new ModrdnPayload(ModrdnKind.RENAME, writeJson(body));
+        }
+        // flat/org or group with parent change: use /move
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("targetOrgDn", newParent);
+        return new ModrdnPayload(ModrdnKind.MOVE, writeJson(body));
+    }
+
+    /** Result of {@link #buildModrdnPayload(LscModifications)}. */
+    public static final class ModrdnPayload {
+        public final ModrdnKind kind;
+        public final String body;
+
+        public ModrdnPayload(ModrdnKind kind, String body) {
+            this.kind = kind;
+            this.body = body;
+        }
+    }
+
+    public enum ModrdnKind { MOVE, RENAME }
+
+    // -------------------------------------------------------------------
+    // helpers
+    // -------------------------------------------------------------------
+
+    /**
+     * Collapse a values list to a JSON-friendly representation:
+     * single value → scalar, multi-value → array, empty → {@code null}.
+     * Fails on binary data.
+     */
+    private static Object collapse(String attr, List<Object> values) throws LscServiceException {
+        List<Object> sanitized = sanitizeValues(attr, values);
+        if (sanitized.isEmpty()) return null;
+        if (sanitized.size() == 1) return sanitized.get(0);
+        return sanitized;
+    }
+
+    private static List<Object> sanitizeValues(String attr, List<Object> values) throws LscServiceException {
+        List<Object> out = new ArrayList<>();
+        if (values == null) return out;
+        for (Object v : values) {
+            if (v == null) continue;
+            if (v instanceof byte[]) {
+                byte[] b = (byte[]) v;
+                String s = decodeUtf8Strict(b);
+                if (s == null) {
+                    throw new LscServiceException(
+                            "binary attributes not supported in this version: " + attr);
+                }
+                out.add(s);
+            } else {
+                out.add(v);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Try to decode bytes as strict UTF-8. Returns {@code null} if
+     * the bytes do not form valid UTF-8 (which we treat as opaque
+     * binary).
+     */
+    private static String decodeUtf8Strict(byte[] bytes) {
+        try {
+            return StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(java.nio.ByteBuffer.wrap(bytes))
+                    .toString();
+        } catch (CharacterCodingException e) {
+            return null;
+        }
+    }
+
+    private static <T> List<T> safeList(List<T> list) {
+        return list == null ? Collections.emptyList() : list;
+    }
+
+    public static String writeJson(Object o) throws LscServiceException {
+        try {
+            return MAPPER.writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            throw new LscServiceException("failed to encode JSON payload: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Extract the {@code member} attribute values from a ldap-rest group
+     * response body. Accepts the value as either an array of strings
+     * (the common case) or a single string. Returns an empty list if
+     * the response has no {@code member} field.
+     */
+    public static List<Object> readMembers(String json) throws LscServiceException {
+        if (json == null || json.isEmpty()) return Collections.emptyList();
+        try {
+            com.fasterxml.jackson.databind.JsonNode root = MAPPER.readTree(json);
+            com.fasterxml.jackson.databind.JsonNode m = root.get("member");
+            if (m == null || m.isNull()) return Collections.emptyList();
+            List<Object> out = new ArrayList<>();
+            if (m.isArray()) {
+                for (com.fasterxml.jackson.databind.JsonNode v : m) {
+                    if (v != null && !v.isNull()) out.add(v.asText());
+                }
+            } else if (m.isTextual()) {
+                out.add(m.asText());
+            }
+            return out;
+        } catch (JsonProcessingException e) {
+            throw new LscServiceException("failed to parse group response JSON: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Lower-case a DN attribute type for comparison; trivial helper
+     * exposed for {@link LdapRestDstService}.
+     */
+    static String lowerType(String type) {
+        return type == null ? "" : type.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/org/lsc/service/ldaprest/ResourceMapper.java
+++ b/src/main/java/org/lsc/service/ldaprest/ResourceMapper.java
@@ -1,0 +1,239 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Objects;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+
+/**
+ * Routes LSC operations to the right ldap-rest endpoint depending on
+ * the configured resource type, and parses LSC-style DNs into
+ * identifiers usable on the wire.
+ *
+ * <p>Three resource families are supported:</p>
+ * <ul>
+ *     <li>{@code groups} — endpoints under {@code /groups}, identified
+ *         by the bare {@code cn} value.</li>
+ *     <li>{@code organizations} — endpoints under {@code /organizations},
+ *         identified by the URL-encoded full DN.</li>
+ *     <li>everything else (e.g. {@code users}) — flat resources where
+ *         the identifier is the RDN value (e.g. {@code uid=alice}'s
+ *         {@code alice}).</li>
+ * </ul>
+ */
+public class ResourceMapper {
+
+    public enum Family { GROUPS, ORGANIZATIONS, FLAT }
+
+    private final String resourceType;
+    private final Family family;
+    private final String apiPrefix;
+
+    public ResourceMapper(String resourceType) {
+        this(resourceType, "/api");
+    }
+
+    public ResourceMapper(String resourceType, String apiPrefix) {
+        this.resourceType = Objects.requireNonNull(resourceType, "resourceType").toLowerCase(Locale.ROOT);
+        this.apiPrefix = Objects.requireNonNull(apiPrefix, "apiPrefix");
+        switch (this.resourceType) {
+            case "groups":
+                this.family = Family.GROUPS;
+                break;
+            case "organizations":
+                this.family = Family.ORGANIZATIONS;
+                break;
+            default:
+                this.family = Family.FLAT;
+        }
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public Family getFamily() {
+        return family;
+    }
+
+    /** {@code /api/v1/ldap/{resource}} — for CREATE. */
+    public String collectionPath() {
+        return apiPrefix + "/v1/ldap/" + resourceType;
+    }
+
+    /** {@code /api/v1/ldap/{resource}/{id}} — for UPDATE/DELETE. */
+    public String itemPath(String dn) {
+        return collectionPath() + "/" + encodeId(dn);
+    }
+
+    /** {@code /api/v1/ldap/{resource}/{id}/move} — for MODRDN flat/org. */
+    public String movePath(String dn) {
+        return itemPath(dn) + "/move";
+    }
+
+    /** {@code /api/v1/ldap/groups/{cn}/rename} — for MODRDN groups. */
+    public String renamePath(String dn) {
+        if (family != Family.GROUPS) {
+            throw new IllegalStateException("rename is only valid for groups");
+        }
+        return itemPath(dn) + "/rename";
+    }
+
+    /** {@code /api/v1/ldap/groups/{cn}/members} — group member add. */
+    public String membersPath(String dn) {
+        if (family != Family.GROUPS) {
+            throw new IllegalStateException("members is only valid for groups");
+        }
+        return itemPath(dn) + "/members";
+    }
+
+    /** {@code /api/v1/ldap/groups/{cn}/members/{member}} — group member delete. */
+    public String memberItemPath(String groupDn, String memberDn) {
+        if (family != Family.GROUPS) {
+            throw new IllegalStateException("members is only valid for groups");
+        }
+        return membersPath(groupDn) + "/" + encode(memberDn);
+    }
+
+    /**
+     * Build the URL-suitable identifier from a LSC main identifier.
+     * For groups/flat resources we want the bare RDN value (so
+     * {@code uid=alice,ou=users,dc=...} → {@code alice}). For
+     * organizations we want the entire DN URL-encoded.
+     */
+    public String encodeId(String dn) {
+        Objects.requireNonNull(dn, "dn");
+        switch (family) {
+            case ORGANIZATIONS:
+                return encode(dn);
+            case GROUPS:
+            case FLAT:
+            default:
+                return encode(rdnValue(dn));
+        }
+    }
+
+    /**
+     * Extract the unescaped RDN value from a DN, parsed via
+     * {@link javax.naming.ldap.LdapName} / {@link javax.naming.ldap.Rdn}
+     * so all RFC 4514 / RFC 2253 escapes are handled correctly
+     * ({@code \,}, {@code \\}, {@code \=}, hex {@code \xx}, leading/trailing
+     * spaces, hex-string DER values, etc.).
+     *
+     * <p>Examples:</p>
+     * <ul>
+     *     <li>{@code uid=alice,ou=users,dc=ex,dc=org} → {@code alice}</li>
+     *     <li>{@code cn=Doe\, John,ou=users,dc=ex,dc=org} → {@code Doe, John}</li>
+     *     <li>{@code cn=Doe\2c John,ou=users,dc=ex,dc=org} → {@code Doe, John}</li>
+     *     <li>{@code alice} → {@code alice} (bare value passthrough)</li>
+     * </ul>
+     *
+     * <p>The result is the *logical* identifier value that ldap-rest
+     * expects in path params (the server re-escapes it itself via
+     * {@code escapeDnValue}). Returning the escaped form would
+     * double-escape on the wire.</p>
+     */
+    public static String rdnValue(String dn) {
+        Objects.requireNonNull(dn, "dn");
+        String trimmed = dn.trim();
+        if (trimmed.isEmpty()) return trimmed;
+        try {
+            LdapName name = new LdapName(trimmed);
+            if (name.isEmpty()) return trimmed;
+            Rdn rdn = name.getRdn(name.size() - 1);
+            Object v = rdn.getValue();
+            return v == null ? "" : v.toString();
+        } catch (InvalidNameException e) {
+            // Bare value (e.g. "alice") is not a valid DN — fall through
+            // and return it as-is. Same for anything LdapName refuses.
+            return trimmed;
+        }
+    }
+
+    /**
+     * Return the parent DN (everything but the leftmost RDN), or {@code ""}
+     * if {@code dn} has no parent (single RDN or bare value). Uses
+     * {@link LdapName} so escape rules are RFC 4514 compliant.
+     */
+    public static String parentDn(String dn) {
+        Objects.requireNonNull(dn, "dn");
+        String trimmed = dn.trim();
+        if (trimmed.isEmpty()) return "";
+        try {
+            LdapName name = new LdapName(trimmed);
+            if (name.size() <= 1) return "";
+            return name.getPrefix(name.size() - 1).toString();
+        } catch (InvalidNameException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Return the first RDN component (e.g. {@code uid=alice}) of a DN,
+     * in its canonical RFC 4514 form. Used internally for diagnostics;
+     * for the unescaped value alone use {@link #rdnValue(String)}.
+     */
+    public static String firstRdn(String dn) {
+        Objects.requireNonNull(dn, "dn");
+        String trimmed = dn.trim();
+        if (trimmed.isEmpty()) return "";
+        try {
+            LdapName name = new LdapName(trimmed);
+            if (name.isEmpty()) return trimmed;
+            return name.getRdn(name.size() - 1).toString();
+        } catch (InvalidNameException e) {
+            return trimmed;
+        }
+    }
+
+    static String encode(String s) {
+        return URLEncoder.encode(s, StandardCharsets.UTF_8)
+                // URLEncoder uses '+' for spaces; ldap-rest decodes
+                // percent-encoded form but not application/x-www-form-urlencoded
+                // for path components, so use %20 to be safe.
+                .replace("+", "%20");
+    }
+}

--- a/src/main/resources/schemas/lsc-core-2.2.xsd
+++ b/src/main/resources/schemas/lsc-core-2.2.xsd
@@ -440,6 +440,36 @@
 		</xsd:complexContent>
 	</xsd:complexType>
 
+	<xsd:complexType name="ldapRestAuthType">
+		<xsd:choice>
+			<xsd:element name="bearer" type="xsd:string" />
+			<xsd:sequence>
+				<xsd:element name="hmacServiceId" type="xsd:string" />
+				<xsd:element name="hmacSecret" type="xsd:string" />
+			</xsd:sequence>
+		</xsd:choice>
+	</xsd:complexType>
+
+	<xsd:complexType name="ldapRestDestinationServiceType">
+		<xsd:complexContent>
+			<xsd:extension base="serviceType">
+				<xsd:sequence>
+					<xsd:element name="baseUrl" type="xsd:string" />
+					<xsd:element name="resourceType" type="xsd:string" />
+					<xsd:element name="apiPrefix" type="xsd:string"
+						default="/api" minOccurs="0" />
+					<xsd:element name="auth" type="ldapRestAuthType" />
+					<xsd:element name="timeoutMs" type="xsd:long"
+						default="10000" minOccurs="0" />
+					<xsd:element name="retries" type="xsd:int"
+						default="3" minOccurs="0" />
+					<xsd:element name="writeDatasetIds" type="valuesType"
+						minOccurs="0" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
 	<xsd:complexType name="multiDestinationServiceType">
 		<xsd:complexContent>
 			<xsd:extension base="serviceType">
@@ -483,6 +513,7 @@
 			<xsd:choice>
 				<xsd:element name="databaseDestinationService" type="databaseDestinationServiceType" />
 				<xsd:element name="ldapDestinationService" type="ldapDestinationServiceType" />
+				<xsd:element name="ldapRestDestinationService" type="ldapRestDestinationServiceType" />
 				<xsd:element name="multiDestinationService" type="multiDestinationServiceType" />
 				<xsd:element name="xaFileDestinationService" type="xaFileDestinationServiceType" />
 				<xsd:element name="pluginDestinationService" type="pluginDestinationServiceType" />

--- a/src/test/java/org/lsc/service/ldaprest/LdapRestAuthTest.java
+++ b/src/test/java/org/lsc/service/ldaprest/LdapRestAuthTest.java
@@ -1,0 +1,166 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.Test;
+
+class LdapRestAuthTest {
+
+    @Test
+    void bearerSetsAuthorizationHeader() {
+        BearerAuth auth = new BearerAuth("abc-123");
+        HttpRequest.Builder b = HttpRequest.newBuilder().uri(URI.create("http://x/y"));
+        auth.apply(b, "POST", "/api/v1/ldap/users", "{\"x\":1}".getBytes(StandardCharsets.UTF_8));
+        HttpRequest req = b.GET().build();
+        Optional<String> h = req.headers().firstValue("Authorization");
+        assertTrue(h.isPresent());
+        assertEquals("Bearer abc-123", h.get());
+    }
+
+    /**
+     * Cross-implementation contract test. The Node server in
+     * test/plugins/auth/hmac.test.ts ("Cross-impl vector") hard-codes the
+     * same expected signature. If either side drifts (signing string format,
+     * body hashing rule, timestamp encoding), both tests fail.
+     *
+     * Vector: secret="test-secret-min-32-chars-long-xxx", method=POST,
+     * path=/api/v1/ldap/users, ts=1700000000000, body={"uid":"alice"}.
+     */
+    @Test
+    void hmacCrossImplVector() {
+        String secret = "test-secret-min-32-chars-long-xxx";
+        String method = "POST";
+        String path = "/api/v1/ldap/users";
+        long ts = 1_700_000_000_000L;
+        byte[] body = "{\"uid\":\"alice\"}".getBytes(StandardCharsets.UTF_8);
+        String expected = "65b065ff10ab2a54de0ab4db485c5744fcdd32a98e2fd24a8cef5240b43bbc94";
+        assertEquals(expected, HmacAuth.computeSignature(secret, method, path, ts, body),
+                "HMAC signature must match the ldap-rest server's vector");
+    }
+
+    @Test
+    void hmacReproducibleSignature() throws Exception {
+        // Reference vector — values are also used by the cross-check
+        // implemented by hand below.
+        String secret = "test-secret-min-32-chars-long-xxx";
+        String serviceId = "lsc";
+        String method = "POST";
+        String path = "/api/v1/ldap/users";
+        // Body uses LinkedHashMap-style insertion order: {"uid":"alice"}.
+        // That's exactly what the translator produces.
+        String body = "{\"uid\":\"alice\"}";
+        long fixedTs = 1_700_000_000_000L;
+
+        // Compute expected signature manually with javax.crypto.Mac
+        String bodyHash = HmacAuth.sha256Hex(body.getBytes(StandardCharsets.UTF_8));
+        String signingString = method + "|" + path + "|" + fixedTs + "|" + bodyHash;
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        byte[] expectedSig = mac.doFinal(signingString.getBytes(StandardCharsets.UTF_8));
+        StringBuilder hex = new StringBuilder();
+        for (byte b : expectedSig) hex.append(String.format("%02x", b));
+        String expectedHex = hex.toString();
+
+        // computeSignature should match
+        String computed = HmacAuth.computeSignature(secret, method, path, fixedTs,
+                body.getBytes(StandardCharsets.UTF_8));
+        assertEquals(expectedHex, computed, "computeSignature must match Mac directly");
+
+        // apply() must produce the same signature in the header
+        HmacAuth auth = new HmacAuth(serviceId, secret, () -> fixedTs);
+        HttpRequest.Builder b = HttpRequest.newBuilder().uri(URI.create("http://x" + path));
+        auth.apply(b, method, path, body.getBytes(StandardCharsets.UTF_8));
+        HttpRequest req = b.POST(HttpRequest.BodyPublishers.ofString(body)).build();
+        String headerValue = req.headers().firstValue("Authorization").orElseThrow();
+        assertEquals("HMAC-SHA256 " + serviceId + ":" + fixedTs + ":" + expectedHex, headerValue);
+    }
+
+    @Test
+    void hmacUsesEmptyBodyHashForGet() {
+        long ts = 1_700_000_000_000L;
+        String secret = "secret";
+        String path = "/api/v1/ldap/users";
+        // For GET, bodyHash must be the empty string and body is ignored.
+        String sigGet = HmacAuth.computeSignature(secret, "GET", path, ts, "ignored".getBytes());
+        // signing string is METHOD|PATH|TS| (with empty bodyHash)
+        String expectedSigningString = "GET|" + path + "|" + ts + "|";
+        String expected = HmacAuth.hmacSha256Hex(secret, expectedSigningString);
+        assertEquals(expected, sigGet);
+    }
+
+    @Test
+    void hmacDeleteUsesEmptyBodyHash() {
+        long ts = 42L;
+        String secret = "k";
+        String path = "/api/v1/ldap/users/alice";
+        String sig = HmacAuth.computeSignature(secret, "DELETE", path, ts, null);
+        String expected = HmacAuth.hmacSha256Hex(secret, "DELETE|" + path + "|" + ts + "|");
+        assertEquals(expected, sig);
+    }
+
+    @Test
+    void sha256HexKnownVector() {
+        // Empty input vector
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                HmacAuth.sha256Hex(new byte[0]));
+        // "abc" vector
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                HmacAuth.sha256Hex("abc".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    void hmacSignatureNonEmpty() {
+        String sig = HmacAuth.computeSignature("key", "POST", "/x", 1L, "body".getBytes());
+        assertNotNull(sig);
+        assertEquals(64, sig.length()); // 32 bytes hex
+    }
+}

--- a/src/test/java/org/lsc/service/ldaprest/LdapRestClientTest.java
+++ b/src/test/java/org/lsc/service/ldaprest/LdapRestClientTest.java
@@ -1,0 +1,221 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lsc.exception.LscServiceException;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+class LdapRestClientTest {
+
+    private WireMockServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void start() {
+        server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.port();
+    }
+
+    @AfterEach
+    void stop() {
+        if (server != null) server.stop();
+    }
+
+    @Test
+    void postSendsBodyAndAuthHeader() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(201).withBody("{\"ok\":true}")));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("tok"), 5000, 0);
+        HttpResponse<String> r = c.post("/api/v1/ldap/users", "{\"uid\":\"alice\"}");
+        assertEquals(201, r.statusCode());
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/users"))
+                .withRequestBody(equalToJson("{\"uid\":\"alice\"}"))
+                .withHeader("Authorization", equalTo("Bearer tok"))
+                .withHeader("Content-Type", equalTo("application/json")));
+    }
+
+    @Test
+    void putSendsBody() throws Exception {
+        server.stubFor(put(urlEqualTo("/api/v1/ldap/users/alice"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        HttpResponse<String> r = c.put("/api/v1/ldap/users/alice", "{\"replace\":{\"sn\":[\"X\"]}}");
+        assertEquals(200, r.statusCode());
+    }
+
+    @Test
+    void deleteWithoutBody() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/users/alice"))
+                .willReturn(aResponse().withStatus(200)));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        HttpResponse<String> r = c.delete("/api/v1/ldap/users/alice");
+        assertEquals(200, r.statusCode());
+    }
+
+    @Test
+    void getWorks() throws Exception {
+        server.stubFor(get(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(200).withBody("[]")));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        HttpResponse<String> r = c.get("/api/v1/ldap/users");
+        assertEquals(200, r.statusCode());
+    }
+
+    @Test
+    void retriesOn5xxThenSucceeds() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .inScenario("retry")
+                .whenScenarioStateIs(com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED)
+                .willReturn(aResponse().withStatus(503))
+                .willSetStateTo("after1"));
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .inScenario("retry")
+                .whenScenarioStateIs("after1")
+                .willReturn(aResponse().withStatus(503))
+                .willSetStateTo("after2"));
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .inScenario("retry")
+                .whenScenarioStateIs("after2")
+                .willReturn(aResponse().withStatus(201).withBody("{\"ok\":true}")));
+
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 3,
+                HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        HttpResponse<String> r = c.post("/api/v1/ldap/users", "{}");
+        assertEquals(201, r.statusCode());
+        // 3 attempts total
+        assertEquals(3, server.getAllServeEvents().size());
+    }
+
+    @Test
+    void retriesExhaustedOn5xxThrows() {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(500)));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 2,
+                HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> c.post("/api/v1/ldap/users", "{}"));
+        assertTrue(ex.getMessage().contains("HTTP 500"));
+    }
+
+    @Test
+    void non2xxNon5xxFailsImmediately() {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(400).withBody("{\"error\":\"bad\"}")));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 3,
+                HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> c.post("/api/v1/ldap/users", "{}"));
+        assertTrue(ex.getMessage().contains("HTTP 400"));
+        // No retries: only 1 server call
+        assertEquals(1, server.getAllServeEvents().size());
+    }
+
+    @Test
+    void timeoutCausesException() throws Exception {
+        server.stubFor(post(urlEqualTo("/slow"))
+                .willReturn(aResponse().withStatus(200).withFixedDelay(2000)));
+        LdapRestClient c = new LdapRestClient(baseUrl, new BearerAuth("t"), 200, 0,
+                HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        assertThrows(LscServiceException.class, () -> c.post("/slow", "{}"));
+    }
+
+    @Test
+    void hmacAuthHeaderIsPresent() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(201)));
+        LdapRestClient c = new LdapRestClient(baseUrl,
+                new HmacAuth("svc", "very-long-secret-32-chars-min-xxx", () -> 1234L),
+                5000, 0);
+        c.post("/api/v1/ldap/users", "{\"uid\":\"x\"}");
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/users"))
+                .withHeader("Authorization",
+                        equalTo("HMAC-SHA256 svc:1234:" + HmacAuth.computeSignature(
+                                "very-long-secret-32-chars-min-xxx",
+                                "POST", "/api/v1/ldap/users", 1234L,
+                                "{\"uid\":\"x\"}".getBytes(StandardCharsets.UTF_8)))));
+    }
+
+    @Test
+    void retriesOnIoExceptionThenThrows() {
+        // Use an unbound port to force connection refused / IOException
+        int port;
+        try (java.net.ServerSocket s = new java.net.ServerSocket(0)) {
+            port = s.getLocalPort();
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+        // socket closed → port unbound
+        LdapRestClient c = new LdapRestClient("http://127.0.0.1:" + port,
+                new BearerAuth("t"), 1000, 1, HttpClient.newHttpClient(), ms -> { /* no-op */ });
+        assertThrows(LscServiceException.class, () -> c.post("/x", "{}"));
+    }
+
+    @Test
+    void baseUrlTrailingSlashIsStripped() throws Exception {
+        server.stubFor(get(urlEqualTo("/x")).willReturn(aResponse().withStatus(200)));
+        LdapRestClient c = new LdapRestClient(baseUrl + "/", new BearerAuth("t"), 5000, 0);
+        HttpResponse<String> r = c.get("/x");
+        assertEquals(200, r.statusCode());
+    }
+}

--- a/src/test/java/org/lsc/service/ldaprest/LdapRestDstServiceConfigTest.java
+++ b/src/test/java/org/lsc/service/ldaprest/LdapRestDstServiceConfigTest.java
@@ -1,0 +1,210 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.lsc.configuration.LdapRestAuthType;
+import org.lsc.configuration.LdapRestDestinationServiceType;
+import org.lsc.configuration.TaskType;
+import org.lsc.exception.LscServiceException;
+
+class LdapRestDstServiceConfigTest {
+
+    /**
+     * Build a {@link LdapRestDestinationServiceType} programmatically
+     * using the JAXB setters. This mimics what JAXB does at runtime
+     * when parsing {@code lsc.xml}.
+     */
+    private LdapRestDestinationServiceType svc(String baseUrl, String resourceType,
+                                               LdapRestAuthType auth) {
+        LdapRestDestinationServiceType s = new LdapRestDestinationServiceType();
+        s.setBaseUrl(baseUrl);
+        s.setResourceType(resourceType);
+        s.setAuth(auth);
+        return s;
+    }
+
+    private LdapRestAuthType bearer(String token) {
+        LdapRestAuthType a = new LdapRestAuthType();
+        a.setBearer(token);
+        return a;
+    }
+
+    private LdapRestAuthType hmac(String id, String secret) {
+        LdapRestAuthType a = new LdapRestAuthType();
+        a.setHmacServiceId(id);
+        a.setHmacSecret(secret);
+        return a;
+    }
+
+    @Test
+    void parsesBaseUrlAndResourceTypeAndBearer() throws Exception {
+        LdapRestDestinationServiceType s = svc("https://api.test/", "users", bearer("tok"));
+        s.setTimeoutMs(2500L);
+        s.setRetries(5);
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(s);
+        assertEquals("https://api.test/", cfg.baseUrl);
+        assertEquals("users", cfg.resourceType);
+        assertEquals(2500L, cfg.timeoutMs);
+        assertEquals(5, cfg.retries);
+        assertTrue(cfg.auth instanceof BearerAuth);
+    }
+
+    @Test
+    void parsesHmacAuth() throws Exception {
+        LdapRestDestinationServiceType s = svc("https://api.test", "groups",
+                hmac("lsc", "secret-32-chars-min-aaaaaaaaaaaaa"));
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(s);
+        assertTrue(cfg.auth instanceof HmacAuth);
+    }
+
+    @Test
+    void requiresBaseUrl() throws Exception {
+        LdapRestDestinationServiceType s = svc(null, "users", bearer("t"));
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(s));
+        assertTrue(ex.getMessage().contains("baseUrl"));
+    }
+
+    @Test
+    void requiresResourceType() throws Exception {
+        LdapRestDestinationServiceType s = svc("https://api.test", null, bearer("t"));
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(s));
+        assertTrue(ex.getMessage().contains("resourceType"));
+    }
+
+    @Test
+    void requiresAuth() throws Exception {
+        LdapRestDestinationServiceType s = svc("https://api.test", "users", null);
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(s));
+        assertTrue(ex.getMessage().contains("auth"));
+    }
+
+    @Test
+    void requiresAuthCredentials() throws Exception {
+        // <auth/> present but empty
+        LdapRestDestinationServiceType s = svc("https://api.test", "users", new LdapRestAuthType());
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(s));
+        assertTrue(ex.getMessage().contains("bearer") || ex.getMessage().contains("hmac"));
+    }
+
+    @Test
+    void defaultsAreApplied() throws Exception {
+        LdapRestDestinationServiceType s = svc("https://api.test", "users", bearer("t"));
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(s);
+        assertEquals(10_000L, cfg.timeoutMs);
+        assertEquals(3, cfg.retries);
+        assertEquals("/api", cfg.apiPrefix);
+    }
+
+    @Test
+    void rejectsZeroOrNegativeTimeout() throws Exception {
+        for (long bad : new long[] { 0L, -1L, -10000L }) {
+            LdapRestDestinationServiceType s = svc("https://api.test", "users", bearer("t"));
+            s.setTimeoutMs(bad);
+            LscServiceException ex = assertThrows(LscServiceException.class,
+                    () -> LdapRestDstService.parseConfig(s),
+                    "expected rejection for timeoutMs=" + bad);
+            assertTrue(ex.getMessage().contains("timeoutMs"),
+                    "message should mention timeoutMs, got: " + ex.getMessage());
+        }
+    }
+
+    @Test
+    void rejectsNegativeRetries() throws Exception {
+        LdapRestDestinationServiceType s = svc("https://api.test", "users", bearer("t"));
+        s.setRetries(-1);
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(s));
+        assertTrue(ex.getMessage().contains("retries"),
+                "message should mention retries, got: " + ex.getMessage());
+    }
+
+    @Test
+    void acceptsZeroRetries() throws Exception {
+        // 0 retries is valid (= no retry, single attempt)
+        LdapRestDestinationServiceType s = svc("https://api.test", "users", bearer("t"));
+        s.setRetries(0);
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(s);
+        assertEquals(0, cfg.retries);
+    }
+
+    @Test
+    void normalisesApiPrefix() throws Exception {
+        LdapRestDestinationServiceType s = svc("https://api.test", "users", bearer("t"));
+        s.setApiPrefix("/api/");
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(s);
+        assertEquals("/api", cfg.apiPrefix);
+
+        s.setApiPrefix("api");
+        cfg = LdapRestDstService.parseConfig(s);
+        assertEquals("/api", cfg.apiPrefix);
+
+        s.setApiPrefix("/");
+        cfg = LdapRestDstService.parseConfig(s);
+        assertEquals("", cfg.apiPrefix);
+    }
+
+    @Test
+    void parsesFromTaskTypeWrapper() throws Exception {
+        LdapRestDestinationServiceType s = svc("https://api.test", "users", bearer("t"));
+        TaskType task = new TaskType();
+        task.setLdapRestDestinationService(s);
+        LdapRestDstService.Config cfg = LdapRestDstService.parseConfig(task);
+        assertEquals("https://api.test", cfg.baseUrl);
+        assertEquals("users", cfg.resourceType);
+    }
+
+    @Test
+    void taskWithoutLdapRestServiceIsRejected() {
+        TaskType task = new TaskType();
+        LscServiceException ex = assertThrows(LscServiceException.class,
+                () -> LdapRestDstService.parseConfig(task));
+        assertTrue(ex.getMessage().contains("ldapRestDestinationService")
+                || ex.getMessage().contains("not configured"));
+    }
+}

--- a/src/test/java/org/lsc/service/ldaprest/LdapRestDstServiceIntegrationTest.java
+++ b/src/test/java/org/lsc/service/ldaprest/LdapRestDstServiceIntegrationTest.java
@@ -1,0 +1,318 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.lsc.LscDatasetModification;
+import org.lsc.LscDatasetModification.LscDatasetModificationType;
+import org.lsc.LscModificationType;
+import org.lsc.LscModifications;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+class LdapRestDstServiceIntegrationTest {
+
+    private WireMockServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void start() {
+        server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        server.start();
+        baseUrl = "http://127.0.0.1:" + server.port();
+    }
+
+    @AfterEach
+    void stop() {
+        if (server != null) server.stop();
+    }
+
+    private LdapRestDstService usersService() {
+        ResourceMapper mapper = new ResourceMapper("users");
+        LdapRestClient client = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        return new LdapRestDstService(client, mapper);
+    }
+
+    private LdapRestDstService groupsService() {
+        ResourceMapper mapper = new ResourceMapper("groups");
+        LdapRestClient client = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        return new LdapRestDstService(client, mapper);
+    }
+
+    private LdapRestDstService orgsService() {
+        ResourceMapper mapper = new ResourceMapper("organizations");
+        LdapRestClient client = new LdapRestClient(baseUrl, new BearerAuth("t"), 5000, 0);
+        return new LdapRestDstService(client, mapper);
+    }
+
+    private LscModifications lm(LscModificationType op, String main) {
+        LscModifications m = new LscModifications(op, "task");
+        m.setMainIdentifer(main);
+        return m;
+    }
+
+    private LscDatasetModification rep(String name, Object... vals) {
+        return new LscDatasetModification(LscDatasetModificationType.REPLACE_VALUES,
+                name, Arrays.asList(vals));
+    }
+
+    private LscDatasetModification add(String name, Object... vals) {
+        return new LscDatasetModification(LscDatasetModificationType.ADD_VALUES,
+                name, Arrays.asList(vals));
+    }
+
+    private LscDatasetModification del(String name, Object... vals) {
+        return new LscDatasetModification(LscDatasetModificationType.DELETE_VALUES,
+                name, Arrays.asList(vals));
+    }
+
+    @Test
+    void createUserPostsCollection() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users"))
+                .willReturn(aResponse().withStatus(201).withBody("{}")));
+        LscModifications m = lm(LscModificationType.CREATE_OBJECT, "uid=alice,ou=users,dc=ex,dc=org");
+        m.setLscAttributeModifications(Arrays.asList(
+                rep("uid", "alice"),
+                rep("sn", "Doe"),
+                rep("cn", "Alice Doe")));
+        assertTrue(usersService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/users"))
+                .withRequestBody(equalToJson("{\"uid\":\"alice\",\"sn\":\"Doe\",\"cn\":\"Alice Doe\"}"))
+                .withHeader("Authorization", equalTo("Bearer t")));
+    }
+
+    @Test
+    void updateUserPutsItem() throws Exception {
+        server.stubFor(put(urlEqualTo("/api/v1/ldap/users/alice"))
+                .willReturn(aResponse().withStatus(200).withBody("{}")));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "uid=alice,ou=users,dc=ex,dc=org");
+        m.setLscAttributeModifications(Arrays.asList(
+                rep("sn", "NewName"),
+                add("mail", "a@x.fr"),
+                del("description")));
+        assertTrue(usersService().apply(m));
+        server.verify(putRequestedFor(urlEqualTo("/api/v1/ldap/users/alice"))
+                .withRequestBody(equalToJson(
+                        "{\"replace\":{\"sn\":[\"NewName\"]},\"add\":{\"mail\":[\"a@x.fr\"]},\"delete\":[\"description\"]}")));
+    }
+
+    @Test
+    void deleteUser() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/users/alice"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.DELETE_OBJECT, "uid=alice,ou=users,dc=ex,dc=org");
+        assertTrue(usersService().apply(m));
+        server.verify(deleteRequestedFor(urlEqualTo("/api/v1/ldap/users/alice")));
+    }
+
+    @Test
+    void deleteUser404IsTreatedAsSuccess() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/users/ghost"))
+                .willReturn(aResponse().withStatus(404).withBody("{\"error\":\"not found\"}")));
+        LscModifications m = lm(LscModificationType.DELETE_OBJECT, "uid=ghost,ou=users,dc=ex,dc=org");
+        assertTrue(usersService().apply(m));
+    }
+
+    @Test
+    void modrdnUserCallsMove() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/users/alice/move"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.CHANGE_ID, "uid=alice,ou=users,dc=ex,dc=org");
+        m.setNewMainIdentifier("uid=alice,ou=admins,dc=ex,dc=org");
+        assertTrue(usersService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/users/alice/move"))
+                .withRequestBody(equalToJson("{\"targetOrgDn\":\"ou=admins,dc=ex,dc=org\"}")));
+    }
+
+    @Test
+    void createGroupPostsCollection() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/groups"))
+                .willReturn(aResponse().withStatus(201)));
+        LscModifications m = lm(LscModificationType.CREATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        m.setLscAttributeModifications(Arrays.asList(
+                rep("cn", "admins"),
+                rep("description", "Admins"),
+                rep("member", "uid=alice,ou=users,dc=ex,dc=org")));
+        assertTrue(groupsService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/groups"))
+                .withRequestBody(equalToJson(
+                        "{\"cn\":\"admins\",\"description\":\"Admins\",\"member\":\"uid=alice,ou=users,dc=ex,dc=org\"}")));
+    }
+
+    @Test
+    void updateGroupAddMemberUsesMembersEndpoint() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/groups/admins/members"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        m.setLscAttributeModifications(Collections.singletonList(
+                add("member", "uid=alice,ou=users,dc=ex,dc=org")));
+        assertTrue(groupsService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/groups/admins/members"))
+                .withRequestBody(equalToJson(
+                        "{\"member\":\"uid=alice,ou=users,dc=ex,dc=org\"}")));
+    }
+
+    @Test
+    void updateGroupDeleteMemberUsesMembersEndpoint() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/groups/admins/members/uid%3Dalice%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        m.setLscAttributeModifications(Collections.singletonList(
+                del("member", "uid=alice,ou=users,dc=ex,dc=org")));
+        assertTrue(groupsService().apply(m));
+    }
+
+    @Test
+    void updateGroupAttributeWideDeleteOnMemberFetchesAndRemovesAll() throws Exception {
+        // Reconcile: GET the group, parse "member" array, fire one DELETE per member.
+        server.stubFor(get(urlEqualTo("/api/v1/ldap/groups/admins"))
+                .willReturn(aResponse().withStatus(200).withBody(
+                        "{\"cn\":\"admins\",\"member\":["
+                        + "\"uid=alice,ou=users,dc=ex,dc=org\","
+                        + "\"uid=bob,ou=users,dc=ex,dc=org\"]}")));
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/groups/admins/members/uid%3Dalice%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/groups/admins/members/uid%3Dbob%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        // attribute-wide DELETE: empty values list
+        m.setLscAttributeModifications(Collections.singletonList(
+                new LscDatasetModification(LscDatasetModificationType.DELETE_VALUES,
+                        "member", Collections.emptyList())));
+        assertTrue(groupsService().apply(m));
+
+        server.verify(deleteRequestedFor(urlEqualTo(
+                "/api/v1/ldap/groups/admins/members/uid%3Dalice%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg")));
+        server.verify(deleteRequestedFor(urlEqualTo(
+                "/api/v1/ldap/groups/admins/members/uid%3Dbob%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg")));
+    }
+
+    @Test
+    void updateGroupNonMemberAttributeUsesPut() throws Exception {
+        server.stubFor(put(urlEqualTo("/api/v1/ldap/groups/admins"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        m.setLscAttributeModifications(Collections.singletonList(
+                rep("description", "New Description")));
+        assertTrue(groupsService().apply(m));
+        server.verify(putRequestedFor(urlEqualTo("/api/v1/ldap/groups/admins"))
+                .withRequestBody(equalToJson(
+                        "{\"replace\":{\"description\":[\"New Description\"]}}")));
+    }
+
+    @Test
+    void deleteGroup() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/groups/admins"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.DELETE_OBJECT, "cn=admins,ou=groups,dc=ex,dc=org");
+        assertTrue(groupsService().apply(m));
+    }
+
+    @Test
+    void renameGroupUsesRenameEndpoint() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/groups/oldcn/rename"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.CHANGE_ID, "cn=oldcn,ou=groups,dc=ex,dc=org");
+        m.setNewMainIdentifier("cn=newcn,ou=groups,dc=ex,dc=org");
+        assertTrue(groupsService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/groups/oldcn/rename"))
+                .withRequestBody(equalToJson("{\"newCn\":\"newcn\"}")));
+    }
+
+    @Test
+    void createOrganizationPostsCollection() throws Exception {
+        server.stubFor(post(urlEqualTo("/api/v1/ldap/organizations"))
+                .willReturn(aResponse().withStatus(201)));
+        LscModifications m = lm(LscModificationType.CREATE_OBJECT, "ou=sales,dc=ex,dc=org");
+        m.setLscAttributeModifications(Arrays.asList(
+                rep("ou", "sales"),
+                rep("description", "Sales")));
+        assertTrue(orgsService().apply(m));
+        server.verify(postRequestedFor(urlEqualTo("/api/v1/ldap/organizations"))
+                .withRequestBody(equalToJson("{\"ou\":\"sales\",\"description\":\"Sales\"}")));
+    }
+
+    @Test
+    void deleteOrganizationUsesEncodedDn() throws Exception {
+        server.stubFor(delete(urlEqualTo("/api/v1/ldap/organizations/ou%3Dsales%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.DELETE_OBJECT, "ou=sales,dc=ex,dc=org");
+        assertTrue(orgsService().apply(m));
+    }
+
+    @Test
+    void updateOrganizationPutsEncodedDn() throws Exception {
+        server.stubFor(put(urlEqualTo("/api/v1/ldap/organizations/ou%3Dsales%2Cdc%3Dex%2Cdc%3Dorg"))
+                .willReturn(aResponse().withStatus(200)));
+        LscModifications m = lm(LscModificationType.UPDATE_OBJECT, "ou=sales,dc=ex,dc=org");
+        m.setLscAttributeModifications(Collections.singletonList(rep("description", "Up")));
+        assertTrue(orgsService().apply(m));
+    }
+
+    @Test
+    void readMethodsAreEmpty() throws Exception {
+        LdapRestDstService svc = usersService();
+        assertEquals(null, svc.getBean("alice", new org.lsc.LscDatasets(), false));
+        assertTrue(svc.getListPivots().isEmpty());
+        assertTrue(svc.getSupportedConnectionType().isEmpty());
+        assertTrue(svc.getWriteDatasetIds().isEmpty());
+    }
+}

--- a/src/test/java/org/lsc/service/ldaprest/ModificationTranslatorTest.java
+++ b/src/test/java/org/lsc/service/ldaprest/ModificationTranslatorTest.java
@@ -1,0 +1,339 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.lsc.LscDatasetModification;
+import org.lsc.LscDatasetModification.LscDatasetModificationType;
+import org.lsc.LscModificationType;
+import org.lsc.LscModifications;
+import org.lsc.exception.LscServiceException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ModificationTranslatorTest {
+
+    private static final ObjectMapper M = new ObjectMapper();
+
+    private LscModifications mods(LscModificationType op, String mainId,
+                                  LscDatasetModification... attrs) {
+        LscModifications m = new LscModifications(op, "test-task");
+        m.setMainIdentifer(mainId);
+        m.setLscAttributeModifications(Arrays.asList(attrs));
+        return m;
+    }
+
+    private LscDatasetModification attr(LscDatasetModificationType op, String name, Object... vals) {
+        return new LscDatasetModification(op, name, Arrays.asList(vals));
+    }
+
+    private Map<?, ?> parse(String json) throws Exception {
+        return M.readValue(json, Map.class);
+    }
+
+    // ---------------- CREATE ----------------
+    @Test
+    void createFlatSingleValue() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice,ou=users",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "uid", "alice"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "sn", "Doe"));
+        String json = t.buildCreateBody(lm);
+        Map<?, ?> m = parse(json);
+        assertEquals("alice", m.get("uid"));
+        assertEquals("Doe", m.get("sn"));
+    }
+
+    @Test
+    void createFlatMultiValueAsArray() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=bob",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "objectClass", "top", "person"));
+        String json = t.buildCreateBody(lm);
+        Map<?, ?> m = parse(json);
+        assertEquals(Arrays.asList("top", "person"), m.get("objectClass"));
+    }
+
+    @Test
+    void createGroup() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("groups"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "cn=admins,ou=groups",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "cn", "admins"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "description", "Administrators"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "member",
+                        "uid=alice,ou=users", "uid=bob,ou=users"));
+        String json = t.buildCreateBody(lm);
+        Map<?, ?> m = parse(json);
+        assertEquals("admins", m.get("cn"));
+        assertEquals("Administrators", m.get("description"));
+        assertEquals(Arrays.asList("uid=alice,ou=users", "uid=bob,ou=users"), m.get("member"));
+    }
+
+    @Test
+    void createOrganization() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("organizations"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "ou=sales,dc=ex,dc=org",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "ou", "sales"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "description", "Sales team"));
+        String json = t.buildCreateBody(lm);
+        Map<?, ?> m = parse(json);
+        assertEquals("sales", m.get("ou"));
+        assertEquals("Sales team", m.get("description"));
+    }
+
+    // ---------------- UPDATE ----------------
+    @Test
+    void updateReplaceOnly() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice,ou=users",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "sn", "NewName"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertTrue(m.containsKey("replace"));
+        Map<?, ?> rep = (Map<?, ?>) m.get("replace");
+        assertEquals(Collections.singletonList("NewName"), rep.get("sn"));
+        assertTrue(!m.containsKey("add"));
+        assertTrue(!m.containsKey("delete"));
+    }
+
+    @Test
+    void updateAddOnly() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.ADD_VALUES, "mail", "a@x.fr"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertTrue(m.containsKey("add"));
+        Map<?, ?> add = (Map<?, ?>) m.get("add");
+        assertEquals(Collections.singletonList("a@x.fr"), add.get("mail"));
+    }
+
+    @Test
+    void updateDeleteAttributeWide() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice",
+                new LscDatasetModification(LscDatasetModificationType.DELETE_VALUES,
+                        "telephoneNumber", Collections.emptyList()));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertEquals(Collections.singletonList("telephoneNumber"), m.get("delete"));
+    }
+
+    @Test
+    void updateDeleteSpecificValues() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.DELETE_VALUES, "mail", "old@x.fr"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        Map<?, ?> del = (Map<?, ?>) m.get("delete");
+        assertEquals(Collections.singletonList("old@x.fr"), del.get("mail"));
+    }
+
+    @Test
+    void updateMixReplaceAddDelete() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "sn", "Doe"),
+                attr(LscDatasetModificationType.ADD_VALUES, "mail", "n@x.fr"),
+                attr(LscDatasetModificationType.DELETE_VALUES, "mail", "o@x.fr"),
+                new LscDatasetModification(LscDatasetModificationType.DELETE_VALUES,
+                        "telephoneNumber", Collections.emptyList()));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertTrue(m.containsKey("replace"));
+        assertTrue(m.containsKey("add"));
+        // delete merged: telephoneNumber → [], mail → [o@x.fr]
+        Map<?, ?> del = (Map<?, ?>) m.get("delete");
+        assertEquals(Collections.singletonList("o@x.fr"), del.get("mail"));
+        assertEquals(Collections.emptyList(), del.get("telephoneNumber"));
+    }
+
+    @Test
+    void updateGroupShape() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("groups"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "cn=admins",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "description", "New desc"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        Map<?, ?> rep = (Map<?, ?>) m.get("replace");
+        assertEquals(Collections.singletonList("New desc"), rep.get("description"));
+    }
+
+    @Test
+    void updateOrgShape() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("organizations"));
+        LscModifications lm = mods(LscModificationType.UPDATE_OBJECT, "ou=sales,dc=ex,dc=org",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "description", "Updated"));
+        Map<?, ?> m = parse(t.buildUpdateBody(lm));
+        assertTrue(m.containsKey("replace"));
+    }
+
+    // ---------------- MODRDN ----------------
+    @Test
+    void modrdnFlatProducesMoveTargetOrgDn() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "uid=alice,ou=users,dc=ex,dc=org");
+        lm.setNewMainIdentifier("uid=alice,ou=admins,dc=ex,dc=org");
+        ModificationTranslator.ModrdnPayload p = t.buildModrdnPayload(lm);
+        assertEquals(ModificationTranslator.ModrdnKind.MOVE, p.kind);
+        Map<?, ?> m = parse(p.body);
+        assertEquals("ou=admins,dc=ex,dc=org", m.get("targetOrgDn"));
+    }
+
+    @Test
+    void modrdnGroupSameParentProducesRename() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("groups"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "cn=oldname,ou=groups,dc=ex,dc=org");
+        lm.setNewMainIdentifier("cn=newname,ou=groups,dc=ex,dc=org");
+        ModificationTranslator.ModrdnPayload p = t.buildModrdnPayload(lm);
+        assertEquals(ModificationTranslator.ModrdnKind.RENAME, p.kind);
+        Map<?, ?> m = parse(p.body);
+        assertEquals("newname", m.get("newCn"));
+    }
+
+    @Test
+    void modrdnGroupDifferentParentProducesMove() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("groups"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "cn=admins,ou=groups,dc=ex,dc=org");
+        lm.setNewMainIdentifier("cn=admins,ou=other,dc=ex,dc=org");
+        ModificationTranslator.ModrdnPayload p = t.buildModrdnPayload(lm);
+        assertEquals(ModificationTranslator.ModrdnKind.MOVE, p.kind);
+    }
+
+    @Test
+    void modrdnOrgProducesMove() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("organizations"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "ou=sales,dc=ex,dc=org");
+        lm.setNewMainIdentifier("ou=sales,ou=parent,dc=ex,dc=org");
+        ModificationTranslator.ModrdnPayload p = t.buildModrdnPayload(lm);
+        assertEquals(ModificationTranslator.ModrdnKind.MOVE, p.kind);
+        Map<?, ?> m = parse(p.body);
+        assertEquals("ou=parent,dc=ex,dc=org", m.get("targetOrgDn"));
+    }
+
+    @Test
+    void modrdnFailsWithoutNewMainIdentifier() {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CHANGE_ID, "uid=alice");
+        assertThrows(LscServiceException.class, () -> t.buildModrdnPayload(lm));
+    }
+
+    // ---------------- BINARY ----------------
+    @Test
+    void binaryAttributeRejected() {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        byte[] notUtf8 = new byte[] { (byte) 0xff, (byte) 0xfe, (byte) 0xc3, 0x28 };
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice",
+                new LscDatasetModification(LscDatasetModificationType.REPLACE_VALUES,
+                        "jpegPhoto", java.util.Collections.singletonList(notUtf8)));
+        LscServiceException ex = assertThrows(LscServiceException.class, () -> t.buildCreateBody(lm));
+        assertTrue(ex.getMessage().contains("binary"));
+        assertTrue(ex.getMessage().contains("jpegPhoto"));
+    }
+
+    @Test
+    void utf8BinaryIsAcceptedAsString() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        byte[] utf8 = "héllo".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice",
+                new LscDatasetModification(LscDatasetModificationType.REPLACE_VALUES,
+                        "description", java.util.Collections.singletonList(utf8)));
+        Map<?, ?> m = parse(t.buildCreateBody(lm));
+        assertEquals("héllo", m.get("description"));
+    }
+
+    // ---------------- JSON shape (signature stability) ----------------
+    @Test
+    void jsonOutputIsCompactNoExtraSpaces() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "uid", "alice"));
+        String json = t.buildCreateBody(lm);
+        // No pretty print: no spaces after ':' or ','
+        assertEquals("{\"uid\":\"alice\"}", json);
+    }
+
+    @Test
+    void jsonOutputPreservesInsertionOrder() throws Exception {
+        ModificationTranslator t = new ModificationTranslator(new ResourceMapper("users"));
+        // Insertion order matters for HMAC stability
+        LscModifications lm = mods(LscModificationType.CREATE_OBJECT, "uid=alice",
+                attr(LscDatasetModificationType.REPLACE_VALUES, "z", "1"),
+                attr(LscDatasetModificationType.REPLACE_VALUES, "a", "2"));
+        assertEquals("{\"z\":\"1\",\"a\":\"2\"}", t.buildCreateBody(lm));
+    }
+
+    @Test
+    void writeJsonHelperIsCompact() throws Exception {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("a", 1);
+        body.put("b", "two");
+        assertEquals("{\"a\":1,\"b\":\"two\"}", ModificationTranslator.writeJson(body));
+    }
+
+    @Test
+    void readMembersFromArray() throws Exception {
+        java.util.List<Object> members = ModificationTranslator.readMembers(
+                "{\"cn\":\"admins\",\"member\":[\"uid=alice,ou=users\",\"uid=bob,ou=users\"]}");
+        assertEquals(2, members.size());
+        assertEquals("uid=alice,ou=users", members.get(0));
+        assertEquals("uid=bob,ou=users", members.get(1));
+    }
+
+    @Test
+    void readMembersFromSingleString() throws Exception {
+        java.util.List<Object> members = ModificationTranslator.readMembers(
+                "{\"member\":\"uid=alice,ou=users\"}");
+        assertEquals(1, members.size());
+        assertEquals("uid=alice,ou=users", members.get(0));
+    }
+
+    @Test
+    void readMembersHandlesMissingField() throws Exception {
+        assertEquals(0, ModificationTranslator.readMembers("{\"cn\":\"admins\"}").size());
+        assertEquals(0, ModificationTranslator.readMembers("{}").size());
+        assertEquals(0, ModificationTranslator.readMembers("").size());
+        assertEquals(0, ModificationTranslator.readMembers(null).size());
+    }
+}

--- a/src/test/java/org/lsc/service/ldaprest/ResourceMapperTest.java
+++ b/src/test/java/org/lsc/service/ldaprest/ResourceMapperTest.java
@@ -1,0 +1,184 @@
+/*
+ ****************************************************************************
+ * Ldap Synchronization Connector provides tools to synchronize
+ * electronic identities from a list of data sources including
+ * any database with a JDBC connector, another LDAP directory,
+ * flat files...
+ *
+ *                  ==LICENSE NOTICE==
+ *
+ * Copyright (c) 2008 - 2026 LSC Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the LSC Project nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *                  ==LICENSE NOTICE==
+ ****************************************************************************
+ */
+package org.lsc.service.ldaprest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ResourceMapperTest {
+
+    @Test
+    void rdnValueExtractsSimpleUid() {
+        assertEquals("alice", ResourceMapper.rdnValue("uid=alice,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueExtractsCn() {
+        assertEquals("admins", ResourceMapper.rdnValue("cn=admins,ou=groups,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueOnBareValue() {
+        assertEquals("alice", ResourceMapper.rdnValue("alice"));
+    }
+
+    @Test
+    void rdnValueUnescapesRfc4514EscapedComma() {
+        // ldap-rest expects the unescaped logical value in :id path params;
+        // the server re-escapes it via escapeDnValue. Returning the still-
+        // escaped form would double-escape on the wire.
+        assertEquals("Doe, John",
+                ResourceMapper.rdnValue("cn=Doe\\, John,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueUnescapesHexEscape() {
+        // \2c is an RFC 4514 hex escape for ','
+        assertEquals("Doe, John",
+                ResourceMapper.rdnValue("cn=Doe\\2c John,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void rdnValueUnescapesBackslash() {
+        assertEquals("a\\b", ResourceMapper.rdnValue("cn=a\\\\b,ou=x"));
+    }
+
+    @Test
+    void rdnValueUnescapesPlus() {
+        // \+ is the RFC 4514 escape for '+' (which separates multi-valued RDNs)
+        assertEquals("a+b", ResourceMapper.rdnValue("cn=a\\+b,ou=x"));
+    }
+
+    @Test
+    void rdnValueUnescapesEquals() {
+        assertEquals("foo=bar", ResourceMapper.rdnValue("cn=foo\\=bar,ou=x"));
+    }
+
+    @Test
+    void rdnValueExtractsLeftmostFromMultiValuedRdn() {
+        // Multi-valued RDN: "cn=A+sn=B,...". LdapName parses both as one
+        // RDN; we extract the value picked up by Rdn.getValue() (the
+        // first attribute defined in the RDN).
+        String got = ResourceMapper.rdnValue("cn=Smith+sn=John,ou=users,dc=ex,dc=org");
+        // Either "Smith" or "John" depending on JDK ordering; both are
+        // legitimate logical identifiers for this entry.
+        org.junit.jupiter.api.Assertions.assertTrue(
+                "Smith".equals(got) || "John".equals(got),
+                "expected Smith or John, got: " + got);
+    }
+
+    @Test
+    void parentDnReturnsTail() {
+        assertEquals("ou=users,dc=ex,dc=org",
+                ResourceMapper.parentDn("uid=alice,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void parentDnEmptyForRdnOnly() {
+        assertEquals("", ResourceMapper.parentDn("uid=alice"));
+    }
+
+    @Test
+    void firstRdnHandlesEscapedComma() {
+        assertEquals("cn=Doe\\, John",
+                ResourceMapper.firstRdn("cn=Doe\\, John,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void collectionPathFlat() {
+        ResourceMapper m = new ResourceMapper("users");
+        assertEquals("/api/v1/ldap/users", m.collectionPath());
+    }
+
+    @Test
+    void itemPathFlatUsesRdnValue() {
+        ResourceMapper m = new ResourceMapper("users");
+        assertEquals("/api/v1/ldap/users/alice",
+                m.itemPath("uid=alice,ou=users,dc=ex,dc=org"));
+    }
+
+    @Test
+    void itemPathOrgUsesEncodedDn() {
+        ResourceMapper m = new ResourceMapper("organizations");
+        String got = m.itemPath("ou=sales,dc=ex,dc=org");
+        // commas and equals are URL-encoded
+        assertEquals("/api/v1/ldap/organizations/ou%3Dsales%2Cdc%3Dex%2Cdc%3Dorg", got);
+    }
+
+    @Test
+    void movePathFlat() {
+        ResourceMapper m = new ResourceMapper("users");
+        assertEquals("/api/v1/ldap/users/alice/move",
+                m.movePath("uid=alice,ou=users"));
+    }
+
+    @Test
+    void renamePathOnlyForGroups() {
+        ResourceMapper g = new ResourceMapper("groups");
+        assertEquals("/api/v1/ldap/groups/admins/rename",
+                g.renamePath("cn=admins,ou=groups"));
+        ResourceMapper u = new ResourceMapper("users");
+        assertThrows(IllegalStateException.class, () -> u.renamePath("uid=x"));
+    }
+
+    @Test
+    void membersPath() {
+        ResourceMapper g = new ResourceMapper("groups");
+        assertEquals("/api/v1/ldap/groups/admins/members",
+                g.membersPath("cn=admins,ou=groups"));
+    }
+
+    @Test
+    void memberItemPathEncodesMemberDn() {
+        ResourceMapper g = new ResourceMapper("groups");
+        String p = g.memberItemPath("cn=admins,ou=groups", "uid=alice,ou=users,dc=ex,dc=org");
+        assertEquals(
+                "/api/v1/ldap/groups/admins/members/uid%3Dalice%2Cou%3Dusers%2Cdc%3Dex%2Cdc%3Dorg",
+                p);
+    }
+
+    @Test
+    void resourceTypeIsCaseInsensitive() {
+        ResourceMapper m = new ResourceMapper("Groups");
+        assertEquals(ResourceMapper.Family.GROUPS, m.getFamily());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `IWritableService` implementation, `LdapRestDstService`,
that lets LSC push modifications through a JSON/HTTP API instead of
binding directly to LDAP. The target API is
[ldap-rest](https://github.com/linagora/ldap-rest), which exposes an
LDAP-compatible REST surface on top of an LDAP back-end, plus
fine-grained ACLs, schema validation, audit logging, and webhooks.

## Motivation

Several deployments need an extra layer between LSC and the directory:

- **ACLs at attribute granularity** that the LDAP back-end alone
  cannot express;
- **Audit trail** tied to a service identity (HMAC-SHA256 or bearer);
- **Hooks downstream** (badge / mail / billing system) on each
  successful change;
- **Schema validation** beyond LDAP's `objectClass` constraints.

In production, this is currently shipped as an external plugin via
`<pluginDestinationService implementationClass=…>` (see
[linagora/ldap-rest#76](https://github.com/linagora/ldap-rest/pull/76)).
Folding it into LSC core lets the same configuration live as a typed
`<ldapRestDestinationService>` element, parsed via JAXB, with proper
schema validation in `lsc.xml` rather than a `<xsd:any>` opaque
block.

## What this PR adds

**Schema (`src/main/resources/schemas/lsc-core-2.2.xsd`):**
- new `ldapRestAuthType` (choice of `<bearer>` or
  `<hmacServiceId>`+`<hmacSecret>`);
- new `ldapRestDestinationServiceType` extending `serviceType`
  with `baseUrl`, `resourceType`, `apiPrefix`, `auth`, `timeoutMs`,
  `retries`, `writeDatasetIds`;
- adds `<ldapRestDestinationService>` to the destination-service
  choice in `taskType` (alongside `<ldapDestinationService>`,
  `<pluginDestinationService>`, …).

JAXB types are generated automatically via the existing
`maven-jaxb2-plugin` configuration — no plugin tweaks needed.

**Code (`src/main/java/org/lsc/service/ldaprest/`):**
- `LdapRestDstService` — `IWritableService`, parses
  `task.getLdapRestDestinationService()` (typed JAXB) and dispatches
  CREATE/UPDATE/DELETE/MODRDN to ldap-rest endpoints;
- `LdapRestClient` — HTTP wrapper with retry on 5xx/IOException
  and capped exponential backoff;
- `LdapRestAuth`, `BearerAuth`, `HmacAuth` — pluggable auth
  strategies; `HmacAuth` is wire-compatible with ldap-rest's
  server-side verification (`METHOD|PATH|TS|sha256(body)`);
- `ResourceMapper` — endpoint routing per resource family
  (`groups`, `organizations`, flat) with RFC 4514 escape handling;
- `ModificationTranslator` — `LscModifications` → JSON converter
  with deterministic insertion-order output (signature stability).

**Wiring (`org.lsc.configuration.LscConfiguration`):**
- `getDestinationService`, `setDestinationService`,
  `getServiceImplementation` updated to recognise the new type and
  map it to `LdapRestDstService.class`.

**Tests (`src/test/java/org/lsc/service/ldaprest/`):**
- 91 JUnit 5 tests, covering auth signing (cross-impl HMAC vector),
  HTTP retries, JSON shape stability, RFC 4514 DN parsing, full
  CREATE/UPDATE/DELETE/MODRDN flows for users / groups /
  organizations, group member endpoint routing including
  attribute-wide DELETE reconciliation. WireMock 3.9.1 is added
  as a `<scope>test</scope>` dependency.

**Documentation (`doc/ldap-rest-destination-service.md`):**
- service overview, configuration reference, sample task, supported
  operations, identifier mapping, known limitations.

## Files added / modified

```
A doc/ldap-rest-destination-service.md
M pom.xml                                                    (+wiremock test dep)
M src/main/java/org/lsc/configuration/LscConfiguration.java  (3 hooks)
M src/main/resources/schemas/lsc-core-2.2.xsd                (2 types + 1 choice element)
A src/main/java/org/lsc/service/ldaprest/LdapRestDstService.java
A src/main/java/org/lsc/service/ldaprest/LdapRestClient.java
A src/main/java/org/lsc/service/ldaprest/LdapRestAuth.java
A src/main/java/org/lsc/service/ldaprest/BearerAuth.java
A src/main/java/org/lsc/service/ldaprest/HmacAuth.java
A src/main/java/org/lsc/service/ldaprest/ResourceMapper.java
A src/main/java/org/lsc/service/ldaprest/ModificationTranslator.java
A src/test/java/org/lsc/service/ldaprest/LdapRestDstServiceConfigTest.java
A src/test/java/org/lsc/service/ldaprest/LdapRestDstServiceIntegrationTest.java
A src/test/java/org/lsc/service/ldaprest/LdapRestClientTest.java
A src/test/java/org/lsc/service/ldaprest/LdapRestAuthTest.java
A src/test/java/org/lsc/service/ldaprest/ResourceMapperTest.java
A src/test/java/org/lsc/service/ldaprest/ModificationTranslatorTest.java
```

## Backward compatibility

Existing `<ldapDestinationService>`, `<pluginDestinationService>`,
`<databaseDestinationService>`, `<multiDestinationService>` and
`<xaFileDestinationService>` configurations parse and run
unchanged — only an additional choice was added next to them.
None of the existing classes were modified beyond the three
explicit dispatch hooks in `LscConfiguration`.

## Known limitations

- Binary attributes are not supported (values that fail strict
  UTF-8 decoding raise `LscServiceException`); UTF-8 byte arrays
  are silently accepted.
- Each LSC modification produces one HTTP call; no batching.
  Group `member` reconciliation fans out one DELETE per current
  member.
- `REPLACE` on the group `member` attribute is best-effort
  (add-all-new without computing delete-missing). Use explicit
  ADD/DELETE for deterministic group sync.
- This service is **destination-only**: `getBean` /
  `getListPivots` return empty structures.

## Test plan

- [x] `mvn -B test` passes on JDK 17 (532 tests, 91 new, 0
      failures, 0 errors, 2 pre-existing skipped)
- [x] new tests cover all four LSC operations across `users`,
      `groups`, `organizations`
- [x] HMAC vector cross-checked against the ldap-rest Node server
      (same fixed inputs → same hex signature)
- [x] schema generates JAXB types under
      `target/generated-sources/xjc/org/lsc/configuration/`
- [x] no existing test was modified
- [x] no existing class was modified except the three explicit
      dispatch hooks in `LscConfiguration`