### PR TITLE
Replace manual hex encoding with commons-codec Hex.encodeHex

### DIFF
--- a/src/main/java/org/lsc/utils/SecurityUtils.java
+++ b/src/main/java/org/lsc/utils/SecurityUtils.java
@@ -209,7 +209,7 @@ public class SecurityUtils {
 	 * @return hexadecimal string
 	 */
 	private static final String bytesToHexString(final byte[] bytes) {
-		return new String(Hex.encodeHex(bytes, false));
+		return Hex.encodeHexString(bytes, false);
 	}
 
 	/**

--- a/src/main/java/org/lsc/utils/SecurityUtils.java
+++ b/src/main/java/org/lsc/utils/SecurityUtils.java
@@ -61,6 +61,7 @@ import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.lsc.configuration.LscConfiguration;
 import org.lsc.utils.security.SymmetricEncryption;
@@ -208,15 +209,7 @@ public class SecurityUtils {
 	 * @return hexadecimal string
 	 */
 	private static final String bytesToHexString(final byte[] bytes) {
-		StringBuffer hexString = new StringBuffer();
-		for (int i = 0; i < bytes.length; i++) {
-			int hex = (0xff & bytes[i]);
-			String tmp = Integer.toHexString(hex);
-			tmp = (tmp.length() < 2) ? "0" + tmp : tmp; // if tmp=="9" => tmp=="09"
-			hexString.append(tmp);
-		}
-
-		return hexString.toString().toUpperCase();
+		return new String(Hex.encodeHex(bytes, false));
 	}
 
 	/**

--- a/src/main/java/org/lsc/utils/StringUtils.java
+++ b/src/main/java/org/lsc/utils/StringUtils.java
@@ -62,7 +62,7 @@ public class StringUtils {
 	 * @return the base16 encoded string
 	 */
 	public static String Base64toBase16(String base64encodedstring) {
-		return new String(Hex.encodeHex(Base64.decodeBase64(base64encodedstring.getBytes())));
+		return Hex.encodeHexString(Base64.decodeBase64(base64encodedstring.getBytes()));
 	}
 
 }

--- a/src/main/java/org/lsc/utils/directory/AD.java
+++ b/src/main/java/org/lsc/utils/directory/AD.java
@@ -289,7 +289,7 @@ public class AD {
 	 */
 	public static String binaryGuidToReadableUUID(byte[] GUID) {
 		if (GUID != null) {
-			String hex = new String(Hex.encodeHex(GUID));
+			String hex = Hex.encodeHexString(GUID);
 			return hex.replaceFirst("^(..)(..)(..)(..)(..)(..)(..)(..)(..)(..)(..)(..)(..)(..)(..)(..)$","$4$3$2$1-$6$5-$8$7-$9$10-$11$12$13$14$15$16").toUpperCase();
 		}
 		return "";


### PR DESCRIPTION
## Summary
- Replace hand-rolled `StringBuffer` + `Integer.toHexString()` hex encoding in `SecurityUtils.bytesToHexString()` with `Hex.encodeHex()` from commons-codec

## Why?
The manual implementation used `StringBuffer` (synchronized, slower than `StringBuilder`), manual zero-padding (`tmp.length() < 2 ? "0" + tmp : tmp`), and `toUpperCase()`. Commons-codec's `Hex.encodeHex(bytes, false)` does all of this in one call, is battle-tested, and is already a project dependency.

## Tests
- Existing `SecurityUtilsTest.testcomputeSambaPasswords()` passes (validates Samba LM/NT hash output)