### PR TITLE
Remove deprecated finalize

### DIFF
--- a/src/main/java/org/lsc/jndi/AbstractSimpleJndiService.java
+++ b/src/main/java/org/lsc/jndi/AbstractSimpleJndiService.java
@@ -359,11 +359,7 @@ public abstract class AbstractSimpleJndiService implements Closeable {
 	}
 
 	public void close() throws IOException {
-		try {
-			jndiServices.finalize();
-		} catch (Throwable e) {
-			throw new IOException(e);
-		}
+		jndiServices.close();
 	}
 
 	/**

--- a/src/main/java/org/lsc/jndi/JndiServices.java
+++ b/src/main/java/org/lsc/jndi/JndiServices.java
@@ -118,7 +118,7 @@ import org.slf4j.LoggerFactory;
  * @author Sebastien Bahloul &lt;seb@lsc-project.org&gt;
  * @author Jonathan Clarke &lt;jon@lsc-project.org&gt;
  */
-public final class JndiServices {
+public final class JndiServices implements AutoCloseable {
 
 	protected static final String TLS_CONFIGURATION = "java.naming.tls";
 
@@ -1322,24 +1322,26 @@ public final class JndiServices {
 	}
 
 	/**
-	 * Close connection before this object is deleted by the garbage collector.
-	 * 
-	 * @see java.lang.Object#finalize()
+	 * Close the LDAP connection and release resources.
+	 *
+	 * <p>Cached instances survive close — the next {@link #getInstance} call
+	 * with the same properties will reconnect automatically via
+	 * {@link #initConnection()}.</p>
 	 */
 	@Override
-	protected void finalize() throws Throwable {
-		// Close the TLS connection (revert back to the underlying LDAP association)
+	public void close() throws IOException {
 		if (tlsResponse != null) {
 			tlsResponse.close();
+			tlsResponse = null;
 		}
-
-		// Close the connection to the LDAP server
 		if (ctx != null) {
-			ctx.close();
+			try {
+				ctx.close();
+			} catch (NamingException e) {
+				throw new IOException(e);
+			}
 			ctx = null;
 		}
-
-		super.finalize();
 	}
 
 	/**

--- a/src/test/java/org/lsc/jndi/JndiServicesTest.java
+++ b/src/test/java/org/lsc/jndi/JndiServicesTest.java
@@ -52,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
+import java.util.Properties;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -303,6 +304,53 @@ public class JndiServicesTest extends AbstractLdapTestUnit {
 			LOGGER.debug("key={}, value={}", key, value.getStringValueAttribute(attrName));
 		}
 		LOGGER.debug(" Final count : {}", i);
+	}
+
+	/**
+	 * Test that close() closes the LDAP connection and the instance cannot be used after.
+	 */
+	@Test
+	public final void testClose() throws Exception {
+		// Create a fresh instance (not cached) to avoid affecting other tests
+		Properties props = JndiServices.getLdapProperties(
+				(LdapConnectionType) LscConfiguration.getConnection("dst-ldap"));
+		JndiServices freshInstance = JndiServices.getInstance(props, true);
+
+		// Verify the instance works before close
+		assertNotNull(freshInstance.getContext());
+
+		// Close the instance
+		freshInstance.close();
+
+		// After close, getContext() should return null
+		assertNull(freshInstance.getContext());
+	}
+
+	/**
+	 * Test that close() is idempotent - can be called multiple times safely.
+	 */
+	@Test
+	public final void testCloseIdempotent() throws Exception {
+		Properties props = JndiServices.getLdapProperties(
+				(LdapConnectionType) LscConfiguration.getConnection("dst-ldap"));
+		JndiServices freshInstance = JndiServices.getInstance(props, true);
+
+		// Close multiple times should not throw
+		freshInstance.close();
+		freshInstance.close();
+		freshInstance.close();
+
+		// Instance should still be in a clean state
+		assertNull(freshInstance.getContext());
+	}
+
+	/**
+	 * Test that JndiServices implements AutoCloseable.
+	 */
+	@Test
+	public final void testJndiServicesImplementsAutoCloseable() {
+		assertTrue(dstJndiServices instanceof AutoCloseable,
+				"JndiServices should implement AutoCloseable");
 	}
 
 	public void testAuthenticationThroughJAAS() {

--- a/src/test/java/org/lsc/jndi/JndiServicesTest.java
+++ b/src/test/java/org/lsc/jndi/JndiServicesTest.java
@@ -344,15 +344,6 @@ public class JndiServicesTest extends AbstractLdapTestUnit {
 		assertNull(freshInstance.getContext());
 	}
 
-	/**
-	 * Test that JndiServices implements AutoCloseable.
-	 */
-	@Test
-	public final void testJndiServicesImplementsAutoCloseable() {
-		assertTrue(dstJndiServices instanceof AutoCloseable,
-				"JndiServices should implement AutoCloseable");
-	}
-
 	public void testAuthenticationThroughJAAS() {
 		LoginContext lc = null;
 		String user = "";


### PR DESCRIPTION
Fix #475 

- Implement AutoCloseable on JndiServices
- Replace finalize() with proper close() method
- Simplify AbstractSimpleJndiService.close() delegation
- Add unit tests for close() behavior
