### PR TITLE
fix: clear java.security.krb5.conf system property after GSSAPI authentication

### DIFF
--- a/src/main/java/org/lsc/Launcher.java
+++ b/src/main/java/org/lsc/Launcher.java
@@ -58,6 +58,7 @@ import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.lsc.configuration.LscConfiguration;
+import org.lsc.jndi.JndiServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -205,7 +206,8 @@ public final class Launcher {
 			if (timeLimit > 0) {
 				sync.setTimeLimit(timeLimit);
 			}
-			sync.launch(asyncType, syncType, cleanType);
+			boolean launchResult = sync.launch(asyncType, syncType, cleanType);
+			return launchResult ? 0 : 1;
 		} catch (Exception e) {
 			if (!Configuration.isLoggingSetup()) {
 				System.err.println("Error: " + e.toString());
@@ -215,8 +217,11 @@ public final class Launcher {
 				LOGGER.debug(e.toString(), e);
 			}
 			return 1;
+		} finally {
+			if (asyncType == null || asyncType.isEmpty() || validateConfiguration) {
+				JndiServices.cleanSecurityProperties();
+			}
 		}
-		return 0;
 	}
 
 	/**

--- a/src/main/java/org/lsc/SimpleSynchronize.java
+++ b/src/main/java/org/lsc/SimpleSynchronize.java
@@ -65,6 +65,7 @@ import org.lsc.configuration.LscConfiguration;
 import org.lsc.configuration.TaskType;
 import org.lsc.exception.LscConfigurationException;
 import org.lsc.jmx.LscServerImpl;
+import org.lsc.jndi.JndiServices;
 import org.lsc.runnable.SynchronizeEntryRunner;
 import org.lsc.service.IAsynchronousService;
 import org.lsc.service.SyncReplSourceService;
@@ -137,7 +138,7 @@ public class SimpleSynchronize extends AbstractSynchronize {
 		}
 	}
 
-	private void close() {
+	public void close() {
 		for (Task task: cache.values()) {
 			if (task.getSourceService() instanceof Closeable) {
 				try {
@@ -154,6 +155,7 @@ public class SimpleSynchronize extends AbstractSynchronize {
 				}
 			}
 		}
+		JndiServices.cleanSecurityProperties();
 	}
 
 

--- a/src/main/java/org/lsc/configuration/LscConfiguration.java
+++ b/src/main/java/org/lsc/configuration/LscConfiguration.java
@@ -59,6 +59,7 @@ import org.lsc.beans.syncoptions.ForceSyncOptions;
 import org.lsc.beans.syncoptions.PropertiesBasedSyncOptions;
 import org.lsc.exception.LscConfigurationException;
 import org.lsc.exception.LscException;
+import org.lsc.jndi.JndiServices;
 import org.lsc.jndi.PullableJndiSrcService;
 import org.lsc.jndi.SimpleJndiDstService;
 import org.lsc.service.MultipleDstService;
@@ -511,6 +512,7 @@ public class LscConfiguration {
 	public static void reset() {
 		instance = null;
 		original = null;
+		JndiServices.reset();
 	}
 
 	public static void setSyncOptions(TaskType task, SyncOptionsType syncOptions) throws LscConfigurationException {

--- a/src/main/java/org/lsc/jndi/JndiServices.java
+++ b/src/main/java/org/lsc/jndi/JndiServices.java
@@ -329,21 +329,26 @@ public final class JndiServices {
 			props.setProperty(DirContext.SECURITY_AUTHENTICATION, connection.getAuthentication().value());
 			props.setProperty(DirContext.SECURITY_PRINCIPAL, connection.getUsername());
 			if (connection.getAuthentication().equals(LdapAuthenticationType.GSSAPI)) {
-				if (System.getProperty("java.security.krb5.conf") != null) {
-					throw new RuntimeException("Multiple Kerberos connections not supported (existing value: "
-							+ System.getProperty("java.security.krb5.conf")
-							+ "). Need to set another LSC instance or unset system property !");
-				} else {
-					System.setProperty("java.security.krb5.conf",
-							new File(Configuration.getConfigurationDirectory(), "krb5.ini").getAbsolutePath());
-				}
-				if (System.getProperty("java.security.auth.login.config") != null) {
-					throw new RuntimeException("Multiple JAAS not supported (existing value: "
-							+ System.getProperty("java.security.auth.login.config")
-							+ "). Need to set another LSC instance or unset system property !");
-				} else {
-					System.setProperty("java.security.auth.login.config",
-							new File(Configuration.getConfigurationDirectory(), "gsseg_jaas.conf").getAbsolutePath());
+				synchronized (JndiServices.class) {
+					String targetKrb5Conf = new File(Configuration.getConfigurationDirectory(), "krb5.ini").getAbsolutePath();
+					String existingKrb5Conf = System.getProperty("java.security.krb5.conf");
+					if (existingKrb5Conf == null) {
+						System.setProperty("java.security.krb5.conf", targetKrb5Conf);
+					} else if (!existingKrb5Conf.equals(targetKrb5Conf)) {
+						throw new RuntimeException("Multiple Kerberos connections not supported (existing value: "
+								+ existingKrb5Conf + ", requested value: " + targetKrb5Conf
+								+ "). Need to set another LSC instance or unset system property !");
+					}
+
+					String targetJaasConf = new File(Configuration.getConfigurationDirectory(), "gsseg_jaas.conf").getAbsolutePath();
+					String existingJaasConf = System.getProperty("java.security.auth.login.config");
+					if (existingJaasConf == null) {
+						System.setProperty("java.security.auth.login.config", targetJaasConf);
+					} else if (!existingJaasConf.equals(targetJaasConf)) {
+						throw new RuntimeException("Multiple JAAS not supported (existing value: "
+								+ existingJaasConf + ", requested value: " + targetJaasConf
+								+ "). Need to set another LSC instance or unset system property !");
+					}
 				}
 				props.setProperty("javax.security.sasl.server.authentication",
 						"" + connection.isSaslMutualAuthentication());
@@ -1396,6 +1401,27 @@ public final class JndiServices {
 
 	public static CallbackHandler getCallbackHandler(String user, String pass) {
 		return new KerberosCallbackHandler(user, pass);
+	}
+
+	/**
+	 * Unset Kerberos and JAAS security system properties and reset cached JAAS configuration.
+	 */
+	public static synchronized void cleanSecurityProperties() {
+		System.clearProperty("java.security.krb5.conf");
+		System.clearProperty("java.security.auth.login.config");
+		try {
+			javax.security.auth.login.Configuration.setConfiguration(null);
+		} catch (Exception e) {
+			LOGGER.warn("Failed to reset JAAS configuration: {}", e.getMessage());
+		}
+	}
+
+	/**
+	 * Reset connections cache and clean security properties.
+	 */
+	public static synchronized void reset() {
+		cache.clear();
+		cleanSecurityProperties();
 	}
 }
 

--- a/src/test/java/org/lsc/jndi/JndiServicesTest.java
+++ b/src/test/java/org/lsc/jndi/JndiServicesTest.java
@@ -49,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URL;
@@ -342,6 +343,169 @@ public class JndiServicesTest extends AbstractLdapTestUnit {
 
         // Instance should still be in a clean state
         assertNull(freshInstance.getContext());
+    }
+
+    @Test
+    public final void testGssapiMultipleCallsSuccess() throws Exception {
+        org.lsc.configuration.LdapConnectionType conn = new org.lsc.configuration.LdapConnectionType();
+        conn.setName("gssapi-ldap");
+        conn.setUrl("ldap://localhost:33389/dc=lsc-project,dc=org");
+        conn.setUsername("user@REALM");
+        conn.setPassword("password");
+        conn.setAuthentication(org.lsc.configuration.LdapAuthenticationType.GSSAPI);
+        conn.setSaslQop(org.lsc.configuration.SaslQopType.AUTH);
+        conn.setTlsActivated(false);
+        conn.setSaslMutualAuthentication(false);
+
+        try {
+            JndiServices.cleanSecurityProperties();
+
+            // First call sets java.security.krb5.conf and java.security.auth.login.config
+            JndiServices.getLdapProperties(conn);
+            assertNotNull(System.getProperty("java.security.krb5.conf"));
+            assertNotNull(System.getProperty("java.security.auth.login.config"));
+
+            // Second call with same configuration succeeds without throwing
+            JndiServices.getLdapProperties(conn);
+            assertNotNull(System.getProperty("java.security.krb5.conf"));
+            assertNotNull(System.getProperty("java.security.auth.login.config"));
+        } finally {
+            JndiServices.cleanSecurityProperties();
+        }
+    }
+
+    @Test
+    public final void testGssapiConflictingKrb5ConfThrowsException() throws Exception {
+        org.lsc.configuration.LdapConnectionType conn = new org.lsc.configuration.LdapConnectionType();
+        conn.setName("gssapi-ldap");
+        conn.setUrl("ldap://localhost:33389/dc=lsc-project,dc=org");
+        conn.setUsername("user@REALM");
+        conn.setPassword("password");
+        conn.setAuthentication(org.lsc.configuration.LdapAuthenticationType.GSSAPI);
+        conn.setSaslQop(org.lsc.configuration.SaslQopType.AUTH);
+        conn.setTlsActivated(false);
+        conn.setSaslMutualAuthentication(false);
+
+        try {
+            JndiServices.cleanSecurityProperties();
+            System.setProperty("java.security.krb5.conf", "/different/path/krb5.conf");
+
+            RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+                JndiServices.getLdapProperties(conn);
+            });
+            assertTrue(thrown.getMessage().contains("Multiple Kerberos connections not supported"));
+        } finally {
+            JndiServices.cleanSecurityProperties();
+        }
+    }
+
+    @Test
+    public final void testGssapiConflictingJaasConfThrowsException() throws Exception {
+        org.lsc.configuration.LdapConnectionType conn = new org.lsc.configuration.LdapConnectionType();
+        conn.setName("gssapi-ldap");
+        conn.setUrl("ldap://localhost:33389/dc=lsc-project,dc=org");
+        conn.setUsername("user@REALM");
+        conn.setPassword("password");
+        conn.setAuthentication(org.lsc.configuration.LdapAuthenticationType.GSSAPI);
+        conn.setSaslQop(org.lsc.configuration.SaslQopType.AUTH);
+        conn.setTlsActivated(false);
+        conn.setSaslMutualAuthentication(false);
+
+        try {
+            JndiServices.cleanSecurityProperties();
+            System.setProperty("java.security.auth.login.config", "/different/path/jaas.conf");
+
+            RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+                JndiServices.getLdapProperties(conn);
+            });
+            assertTrue(thrown.getMessage().contains("Multiple JAAS not supported"));
+        } finally {
+            JndiServices.cleanSecurityProperties();
+        }
+    }
+
+    @Test
+    public final void testCleanSecurityProperties() throws Exception {
+        org.lsc.configuration.LdapConnectionType conn = new org.lsc.configuration.LdapConnectionType();
+        conn.setName("gssapi-ldap");
+        conn.setUrl("ldap://localhost:33389/dc=lsc-project,dc=org");
+        conn.setUsername("user@REALM");
+        conn.setPassword("password");
+        conn.setAuthentication(org.lsc.configuration.LdapAuthenticationType.GSSAPI);
+        conn.setSaslQop(org.lsc.configuration.SaslQopType.AUTH);
+        conn.setTlsActivated(false);
+        conn.setSaslMutualAuthentication(false);
+
+        JndiServices.cleanSecurityProperties();
+        JndiServices.getLdapProperties(conn);
+        assertNotNull(System.getProperty("java.security.krb5.conf"));
+        assertNotNull(System.getProperty("java.security.auth.login.config"));
+
+        JndiServices.cleanSecurityProperties();
+        assertNull(System.getProperty("java.security.krb5.conf"));
+        assertNull(System.getProperty("java.security.auth.login.config"));
+    }
+
+    @Test
+    public final void testLscConfigurationResetCleansSecurityProperties() throws Exception {
+        org.lsc.configuration.LdapConnectionType conn = new org.lsc.configuration.LdapConnectionType();
+        conn.setName("gssapi-ldap");
+        conn.setUrl("ldap://localhost:33389/dc=lsc-project,dc=org");
+        conn.setUsername("user@REALM");
+        conn.setPassword("password");
+        conn.setAuthentication(org.lsc.configuration.LdapAuthenticationType.GSSAPI);
+        conn.setSaslQop(org.lsc.configuration.SaslQopType.AUTH);
+        conn.setTlsActivated(false);
+        conn.setSaslMutualAuthentication(false);
+
+        JndiServices.cleanSecurityProperties();
+        JndiServices.getLdapProperties(conn);
+        assertNotNull(System.getProperty("java.security.krb5.conf"));
+        assertNotNull(System.getProperty("java.security.auth.login.config"));
+
+        LscConfiguration.reset();
+        assertNull(System.getProperty("java.security.krb5.conf"));
+        assertNull(System.getProperty("java.security.auth.login.config"));
+    }
+
+    @Test
+    public final void testGssapiConcurrentCalls() throws Exception {
+        org.lsc.configuration.LdapConnectionType conn = new org.lsc.configuration.LdapConnectionType();
+        conn.setName("gssapi-ldap");
+        conn.setUrl("ldap://localhost:33389/dc=lsc-project,dc=org");
+        conn.setUsername("user@REALM");
+        conn.setPassword("password");
+        conn.setAuthentication(org.lsc.configuration.LdapAuthenticationType.GSSAPI);
+        conn.setSaslQop(org.lsc.configuration.SaslQopType.AUTH);
+        conn.setTlsActivated(false);
+        conn.setSaslMutualAuthentication(false);
+
+        try {
+            JndiServices.cleanSecurityProperties();
+            int threadCount = 8;
+            java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(threadCount);
+            java.util.concurrent.CountDownLatch startLatch = new java.util.concurrent.CountDownLatch(1);
+            java.util.List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>();
+
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(executor.submit(() -> {
+                    try {
+                        startLatch.await();
+                        JndiServices.getLdapProperties(conn);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+            }
+
+            startLatch.countDown();
+            for (java.util.concurrent.Future<?> f : futures) {
+                f.get();
+            }
+            executor.shutdown();
+        } finally {
+            JndiServices.cleanSecurityProperties();
+        }
     }
 
 	public void testAuthenticationThroughJAAS() {

--- a/src/test/resources/etc/gsseg_jaas.conf
+++ b/src/test/resources/etc/gsseg_jaas.conf
@@ -1,0 +1,9 @@
+/** 
+ * Login Configuration for JAAS. 
+ *
+ * Specify that Kerberos v5 is a required login module for the 
+ * JndiServices connection helper.
+ */
+org.lsc.jndi.JndiServices {
+	com.sun.security.auth.module.Krb5LoginModule required client=TRUE useTicketCache=TRUE;
+};

--- a/src/test/resources/etc/krb5.ini
+++ b/src/test/resources/etc/krb5.ini
@@ -1,0 +1,6 @@
+[libdefaults]
+default_realm = LSC-PROJECT.ORG
+[realms]
+LSC-PROJECT.ORG = {
+    kdc = localhost:33389
+}


### PR DESCRIPTION
When using GSSAPI authentication, LSC sets java.security.krb5.conf and java.security.auth.login.config system properties but never clears them.

This causes subsequent LSC runs within the same JVM to fail with 'Multiple Kerberos connections not supported' error.

Changes:
- Add synchronized block in getLdapProperties() for thread safety
- Add cleanSecurityProperties() to clear system properties and reset JAAS
- Add reset() method to clear cache and security properties
- Integrate cleanup in Launcher.run(), SimpleSynchronize.close(), and LscConfiguration.reset()
- Add comprehensive tests including concurrent access test